### PR TITLE
feat: add Kronos CPU as selectable alternative to Ibex

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,3 +12,6 @@
 	path = hw/ip/common_cells
 	url = https://github.com/vladdum/common_cells.git
 	branch = opensoc-patches
+[submodule "hw/ip/kronos_riscv"]
+	path = hw/ip/kronos_riscv
+	url = https://github.com/vladdum/kronos-riscv.git

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ FLOW   ?= fpga-arty
 VIVADO ?= vivado
 TOP    ?= opensoc_top_lean
 JOBS   ?= $(shell nproc)
+CPU    ?= ibex
 
 CORES_ROOT_BASE := --cores-root=. \
                    --cores-root=hw/ip/ibex \
@@ -20,6 +21,19 @@ CORES_ROOT_BASE := --cores-root=. \
                    --cores-root=hw/ip/i2c_controller \
                    --cores-root=hw/ip/uart \
                    --cores-root=hw/ip/ram
+
+ifeq ($(CPU),kronos)
+CORES_ROOT_BASE += --cores-root=hw/ip/kronos_riscv
+LINT_TARGET     := lint-kronos
+SIM_TARGET      := sim-kronos
+SYNTH_TARGET    := synth-kronos
+KRONOS_DEFINES  := --USE_KRONOS 1
+else
+LINT_TARGET     := lint
+SIM_TARGET      := sim
+SYNTH_TARGET    := synth
+KRONOS_DEFINES  :=
+endif
 CORES_ROOT_ACCELS := --cores-root=hw/ip/relu_accel \
                      --cores-root=hw/ip/vec_mac \
                      --cores-root=hw/ip/sg_dma \
@@ -142,6 +156,8 @@ help:
 	@echo "  clean                       Remove build directory"
 	@echo ""
 	@echo "Options"
+	@echo "  CPU=ibex                    Use Ibex CPU (default)"
+	@echo "  CPU=kronos                  Use Kronos single-cycle CPU (Stage 0)"
 	@echo "  TOP=opensoc_top_lean        Build lean core (default, no IPs)"
 	@echo "  TOP=opensoc_top             Build full core (use with ENABLE_* flags)"
 	@echo "  ENABLE_RELU=1               Include ReLU accelerator"
@@ -216,12 +232,13 @@ _reg-run-%: FORCE
 
 .PHONY: lint
 lint:
-	$(FUSESOC) $(CORES_ROOT_BASE) $(CORES_ROOT_ACCELS) run --target=lint \
+	$(FUSESOC) $(CORES_ROOT_BASE) $(CORES_ROOT_ACCELS) run --target=$(LINT_TARGET) \
 	    --flag enable_relu --flag enable_vmac --flag enable_sgdma --flag enable_softmax \
 	    --flag enable_crypto --flag enable_conv1d --flag enable_conv2d --flag enable_gemm \
 	    opensoc:soc:opensoc_top \
 	    --EnableReLU 1 --EnableVMAC 1 --EnableSgDma 1 --EnableSoftmax 1 \
-	    --EnableCrypto 1 --EnableConv1d 1 --EnableConv2d 1 --EnableGemm 1
+	    --EnableCrypto 1 --EnableConv1d 1 --EnableConv2d 1 --EnableGemm 1 \
+	    $(KRONOS_DEFINES)
 
 # ── Simulator build ───────────────────────────────────────────────────────────
 
@@ -236,7 +253,7 @@ build:
 	    echo "[build] $$(( (_now - _build_start) / 60 ))m elapsed..."; \
 	  done ) & \
 	_timer_pid=$$!; \
-	MAKEFLAGS="-j$(JOBS)" $(FUSESOC) $(CORES_ROOT) run --target=sim --setup --build $(FUSESOC_FLAGS) $(BUILD_CORE_$(TOP)) $(FUSESOC_DEFINES); \
+	MAKEFLAGS="-j$(JOBS)" $(FUSESOC) $(CORES_ROOT) run --target=$(SIM_TARGET) --setup --build $(FUSESOC_FLAGS) $(BUILD_CORE_$(TOP)) $(FUSESOC_DEFINES) $(KRONOS_DEFINES); \
 	kill $$_timer_pid 2>/dev/null; wait $$_timer_pid 2>/dev/null; \
 	_build_end=$$(date +%s); \
 	_elapsed=$$(( _build_end - _build_start )); \
@@ -285,12 +302,12 @@ synth-setup-asic:
 	  if [ -d "$(SYNTH_SRC_DIR_ASIC)" ]; then \
 	    echo "synth-setup-asic: completed by another process, skipping"; \
 	  else \
-	    $(FUSESOC) $(CORES_ROOT_BASE) $(CORES_ROOT_ACCELS) run --target=synth --setup \
+	    $(FUSESOC) $(CORES_ROOT_BASE) $(CORES_ROOT_ACCELS) run --target=$(SYNTH_TARGET) --setup \
 	      --flag enable_relu --flag enable_vmac --flag enable_sgdma --flag enable_softmax \
 	      --flag enable_conv1d --flag enable_conv2d --flag enable_gemm \
 	      opensoc:soc:opensoc_top \
 	      --EnableReLU 1 --EnableVMAC 1 --EnableSgDma 1 --EnableSoftmax 1 \
-	      --EnableConv1d 1 --EnableConv2d 1 --EnableGemm 1; \
+	      --EnableConv1d 1 --EnableConv2d 1 --EnableGemm 1 $(KRONOS_DEFINES); \
 	  fi; \
 	  exec 9>&-; \
 	fi

--- a/dv/rtl/opensoc_top_wrapper.sv
+++ b/dv/rtl/opensoc_top_wrapper.sv
@@ -87,6 +87,7 @@ module opensoc_top_wrapper
   );
 `endif
 
+`ifndef USE_KRONOS
   export "DPI-C" function mhpmcounter_num;
 
   function automatic int unsigned mhpmcounter_num();
@@ -98,5 +99,6 @@ module opensoc_top_wrapper
   function automatic longint unsigned mhpmcounter_get(int index);
     return u_opensoc_top.u_top.u_ibex_core.cs_registers_i.mhpmcounter[index];
   endfunction
+`endif  // USE_KRONOS
 
 endmodule

--- a/dv/verilator/opensoc_top_sim.cc
+++ b/dv/verilator/opensoc_top_sim.cc
@@ -6,7 +6,9 @@
 #include <iostream>
 
 #include "Vopensoc_top_wrapper__Syms.h"
+#ifndef USE_KRONOS
 #include "ibex_pcounts.h"
+#endif
 #include "opensoc_top_sim.h"
 #include "verilated_toplevel.h"
 #include "verilator_memutil.h"
@@ -62,6 +64,7 @@ bool OpenSocSim::Finish() {
     return false;
   }
 
+#ifndef USE_KRONOS
   // Set the scope to the root scope, the ibex_pcount_string function otherwise
   // doesn't know the scope itself. Could be moved to ibex_pcount_string, but
   // would require a way to set the scope name from here, similar to MemUtil.
@@ -73,6 +76,7 @@ bool OpenSocSim::Finish() {
 
   std::ofstream pcount_csv("opensoc_top_pcount.csv");
   pcount_csv << ibex_pcount_string(true);
+#endif
 
   return true;
 }

--- a/hw/lint/verilator_waiver.vlt
+++ b/hw/lint/verilator_waiver.vlt
@@ -84,6 +84,14 @@ lint_off -rule DECLFILENAME  -file "*/opensoc_ip_opentitan_aes_0/*"
 lint_off -rule UNUSEDPARAM   -file "*/opensoc_ip_opentitan_aes_0/*"
 lint_off -rule UNUSEDSIGNAL  -file "*/opensoc_ip_opentitan_aes_0/*"
 
+// Kronos RTL: unused signals expected in Stage 0 single-cycle implementation
+// (instr_gnt/err not needed in single-cycle, 64-bit regfile upper bits unused for RV32I)
+lint_off -rule UNUSEDSIGNAL  -file "*/opensoc_ip_kronos_riscv_0/rtl/*"
+
+// Third-party lowRISC prim/sim-shared packages (ibex ecosystem, transitive via opentitan_aes)
+lint_off -rule UNUSEDSIGNAL  -file "*/lowrisc_prim_*"
+lint_off -rule UNUSEDSIGNAL  -file "*/lowrisc_ibex_sim_shared_*"
+
 // Third-party IP: PULP AXI modules — waive all lint rules
 lint_off -rule WIDTH          -file "*/pulp-platform.org*axi*"
 lint_off -rule UNUSED         -file "*/pulp-platform.org*axi*"

--- a/hw/top/opensoc_config_pkg.sv
+++ b/hw/top/opensoc_config_pkg.sv
@@ -11,6 +11,7 @@
 // sets these via +define+NAME=VALUE (vlogdefine).  The `ifndef guards let the
 // command-line define win; if nothing is set the defaults below are used.
 
+`ifndef USE_KRONOS
 `ifndef RV32M
   `define RV32M ibex_pkg::RV32MFast
 `endif
@@ -23,11 +24,15 @@
 `ifndef RegFile
   `define RegFile ibex_pkg::RegFileFF
 `endif
+`endif  // USE_KRONOS
 
 package opensoc_config_pkg;
+`ifndef USE_KRONOS
   import ibex_pkg::*;
+`endif
   import axi_pkg::*;
 
+`ifndef USE_KRONOS
   // -------------------------------------------------------------------------
   // Ibex CPU
   // -------------------------------------------------------------------------
@@ -50,6 +55,7 @@ package opensoc_config_pkg;
   localparam bit          DbgTriggerEn     = 1'b0;
   localparam bit          ICacheECC        = 1'b0;
   localparam bit          BranchPredictor  = 1'b0;
+`endif  // USE_KRONOS
 
   // -------------------------------------------------------------------------
   // Memory

--- a/hw/top/opensoc_derived_config_pkg.sv
+++ b/hw/top/opensoc_derived_config_pkg.sv
@@ -16,13 +16,16 @@
 `include "axi/typedef.svh"
 
 package opensoc_derived_config_pkg;
+`ifndef USE_KRONOS
   import ibex_pkg::*;
+`endif
   import axi_pkg::*;
 
   // =========================================================================
   // Configurable parameters — forwarded from the active config package.
   // =========================================================================
 
+`ifndef USE_KRONOS
   // -------------------------------------------------------------------------
   // Ibex CPU parameters (identical across all targets)
   // -------------------------------------------------------------------------
@@ -44,11 +47,12 @@ package opensoc_derived_config_pkg;
   localparam bit          DbgTriggerEn     = opensoc_config_pkg::DbgTriggerEn;
   localparam bit          ICacheECC        = opensoc_config_pkg::ICacheECC;
   localparam bit          BranchPredictor  = opensoc_config_pkg::BranchPredictor;
-  localparam              SRAMInitFile     = opensoc_config_pkg::SRAMInitFile;
+`endif  // USE_KRONOS
 
   // -------------------------------------------------------------------------
   // Parameters from the unified config
   // -------------------------------------------------------------------------
+  localparam              SRAMInitFile     = opensoc_config_pkg::SRAMInitFile;
   localparam int unsigned   RamDepth         = opensoc_config_pkg::RamDepth;
   localparam bit            EnableReLU       = opensoc_config_pkg::EnableReLU;
   localparam bit            EnableVMAC       = opensoc_config_pkg::EnableVMAC;
@@ -60,6 +64,7 @@ package opensoc_derived_config_pkg;
   localparam bit            EnableGemm       = opensoc_config_pkg::EnableGemm;
   localparam xbar_latency_e XbarLatencyMode  = opensoc_config_pkg::XbarLatencyMode;
 
+`ifndef USE_KRONOS
   // -------------------------------------------------------------------------
   // Register file: FPGA block-RAM RF on Xilinx targets; FF RF for ASIC/sim
   // -------------------------------------------------------------------------
@@ -68,6 +73,7 @@ package opensoc_derived_config_pkg;
 `else
   localparam regfile_e RegFile = opensoc_config_pkg::RegFile;  // macro → RegFileFF
 `endif
+`endif  // USE_KRONOS
 
   // =========================================================================
   // Derived parameters — computed from the config values above

--- a/hw/top/opensoc_top.sv
+++ b/hw/top/opensoc_top.sv
@@ -127,10 +127,6 @@ module opensoc_top
   logic [31:0] data_rdata;
   logic        data_err;
 
-  // ECC integrity signals
-  logic [6:0] data_rdata_intg;
-  logic [6:0] instr_rdata_intg;
-
   // -------------------------------------------------------------------------
   // AXI signal bundles
   // -------------------------------------------------------------------------
@@ -161,8 +157,45 @@ module opensoc_top
   assign rst_sys_n = IO_RST_N;
 
   // -------------------------------------------------------------------------
-  // ECC integrity (SecureIbex only)
+  // CPU instantiation: Ibex (default) or Kronos (USE_KRONOS)
   // -------------------------------------------------------------------------
+  assign ibex_irq_fast = {5'b0, gemm_irq, conv2d_irq, conv1d_irq, softmax_irq, sg_dma_irq, vmac_irq, relu_irq, i2c_irq, pio_irq, uart_irq};
+
+`ifdef USE_KRONOS
+  // -------------------------------------------------------------------------
+  // Kronos single-cycle RISC-V core (Stage 0 golden model)
+  // -------------------------------------------------------------------------
+  kronos_top u_top (
+    .clk_i          (clk_sys),
+    .rst_ni         (rst_sys_n),
+    .instr_req_o    (instr_req),
+    .instr_gnt_i    (instr_gnt),
+    .instr_rvalid_i (instr_rvalid),
+    .instr_addr_o   (instr_addr),
+    .instr_rdata_i  (instr_rdata),
+    .instr_err_i    (instr_err),
+    .data_req_o     (data_req),
+    .data_gnt_i     (data_gnt),
+    .data_rvalid_i  (data_rvalid),
+    .data_we_o      (data_we),
+    .data_be_o      (data_be),
+    .data_addr_o    (data_addr),
+    .data_wdata_o   (data_wdata),
+    .data_rdata_i   (data_rdata),
+    .data_err_i     (data_err),
+    .irq_timer_i    (timer_irq),
+    .irq_fast_i     (ibex_irq_fast),
+    .boot_addr_i    (32'h20000000)
+  );
+
+`else
+  // -------------------------------------------------------------------------
+  // Ibex CPU (default)
+  // -------------------------------------------------------------------------
+  // ECC integrity signals (Ibex only)
+  logic [6:0] data_rdata_intg;
+  logic [6:0] instr_rdata_intg;
+
   if (SecureIbex) begin : g_mem_rdata_ecc
     logic [31:0] unused_data_rdata;
     logic [31:0] unused_instr_rdata;
@@ -181,9 +214,6 @@ module opensoc_top
     assign instr_rdata_intg = '0;
   end
 
-  // -------------------------------------------------------------------------
-  // Ibex CPU
-  // -------------------------------------------------------------------------
   // RVFI signals: declared here so opensoc_top_sim can connect ibex_tracer via
   // hierarchical reference without polluting the module's port list.
 `ifdef RVFI
@@ -347,8 +377,7 @@ module opensoc_top
       .rvfi_ext_expanded_insn_last()
 `endif
     );
-
-    assign ibex_irq_fast = {5'b0, gemm_irq, conv2d_irq, conv1d_irq, softmax_irq, sg_dma_irq, vmac_irq, relu_irq, i2c_irq, pio_irq, uart_irq};
+`endif  // USE_KRONOS
 
   // -------------------------------------------------------------------------
   // AXI bridges: Ibex memory ports → AXI (axi_from_mem)

--- a/opensoc_top.core
+++ b/opensoc_top.core
@@ -3,12 +3,10 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 name: "opensoc:soc:opensoc_top"
-description: "OpenSoC top-level based on ibex_simple_system"
+description: "OpenSoC top-level — Ibex (default) or Kronos CPU"
 filesets:
   files_rtl_base:
     depend:
-      - lowrisc:ibex:ibex_top
-      - lowrisc:prim_generic:all
       - lowrisc:ibex:sim_shared
       - "pulp-platform.org::axi"
       - "opensoc:ip:pio"
@@ -19,6 +17,18 @@ filesets:
       - hw/top/opensoc_config_pkg.sv
       - hw/top/opensoc_derived_config_pkg.sv
       - hw/top/opensoc_top.sv
+    file_type: systemVerilogSource
+
+  # CPU filesets — include exactly one per build
+  files_ibex_cpu:
+    depend:
+      - lowrisc:ibex:ibex_top
+      - lowrisc:prim_generic:all
+    file_type: systemVerilogSource
+
+  files_kronos_cpu:
+    depend:
+      - "opensoc:ip:kronos_riscv"
     file_type: systemVerilogSource
 
   files_relu:
@@ -68,6 +78,7 @@ filesets:
     files:
       - hw/lint/verilator_waiver.vlt: {file_type: vlt}
 
+  # Simulation wrappers — Ibex variant includes ibex_tracer (for RVFI)
   files_sim_sv:
     depend:
       - lowrisc:ibex:ibex_tracer
@@ -75,6 +86,12 @@ filesets:
       - dv/rtl/opensoc_top_wrapper.sv
     file_type: systemVerilogSource
 
+  files_sim_sv_kronos:
+    files:
+      - dv/rtl/opensoc_top_wrapper.sv
+    file_type: systemVerilogSource
+
+  # C++ sim driver — Ibex variant includes ibex_pcounts
   files_verilator_sim:
     depend:
       - lowrisc:dv_verilator:memutil_verilator
@@ -85,10 +102,24 @@ filesets:
       - dv/verilator/opensoc_top_sim.h: {file_type: cppSource, is_include_file: true}
       - dv/verilator/opensoc_top_main.cc: {file_type: cppSource}
 
+  files_verilator_sim_kronos:
+    depend:
+      - lowrisc:dv_verilator:memutil_verilator
+      - lowrisc:dv_verilator:simutil_verilator
+    files:
+      - dv/verilator/opensoc_top_sim.cc: {file_type: cppSource}
+      - dv/verilator/opensoc_top_sim.h: {file_type: cppSource, is_include_file: true}
+      - dv/verilator/opensoc_top_main.cc: {file_type: cppSource}
+
 parameters:
   RVFI:
     datatype: bool
     paramtype: vlogdefine
+
+  USE_KRONOS:
+    datatype: bool
+    paramtype: vlogdefine
+    description: "Select Kronos CPU instead of Ibex (0=Ibex default, 1=Kronos)"
 
   RV32M:
     datatype: str
@@ -166,6 +197,7 @@ targets:
   default: &default_target
     filesets:
       - files_rtl_base
+      - files_ibex_cpu
       - enable_relu ? (files_relu)
       - enable_vmac ? (files_vmac)
       - enable_sgdma ? (files_sgdma)
@@ -193,6 +225,7 @@ targets:
   synth:
     filesets:
       - files_rtl_base
+      - files_ibex_cpu
       - enable_relu ? (files_relu)
       - enable_vmac ? (files_vmac)
       - enable_sgdma ? (files_sgdma)
@@ -203,6 +236,32 @@ targets:
     toplevel: opensoc_top
     default_tool: verilator
     parameters:
+      - EnableReLU
+      - EnableVMAC
+      - EnableSgDma
+      - EnableSoftmax
+      - EnableConv1d
+      - EnableConv2d
+      - EnableGemm
+    tools:
+      verilator:
+        mode: lint-only
+
+  synth-kronos:
+    filesets:
+      - files_rtl_base
+      - files_kronos_cpu
+      - enable_relu ? (files_relu)
+      - enable_vmac ? (files_vmac)
+      - enable_sgdma ? (files_sgdma)
+      - enable_softmax ? (files_softmax)
+      - enable_conv1d ? (files_conv1d)
+      - enable_conv2d ? (files_conv2d)
+      - enable_gemm ? (files_gemm)
+    toplevel: opensoc_top
+    default_tool: verilator
+    parameters:
+      - USE_KRONOS=true
       - EnableReLU
       - EnableVMAC
       - EnableSgDma
@@ -227,9 +286,45 @@ targets:
           - "-Wno-UNOPTFLAT"
           - "--unroll-count 72"
 
+  lint-kronos:
+    filesets:
+      - files_rtl_base
+      - files_kronos_cpu
+      - enable_relu ? (files_relu)
+      - enable_vmac ? (files_vmac)
+      - enable_sgdma ? (files_sgdma)
+      - enable_softmax ? (files_softmax)
+      - enable_crypto ? (files_crypto)
+      - enable_conv1d ? (files_conv1d)
+      - enable_conv2d ? (files_conv2d)
+      - enable_gemm ? (files_gemm)
+      - files_lint_verilator
+    toplevel: opensoc_top
+    parameters:
+      - USE_KRONOS=true
+      - EnableReLU
+      - EnableVMAC
+      - EnableSgDma
+      - EnableSoftmax
+      - EnableCrypto
+      - EnableConv1d
+      - EnableConv2d
+      - EnableGemm
+    default_tool: verilator
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"
+          - "-Wno-REDEFMACRO"
+          - "-Wno-SYNCASYNCNET"
+          - "-Wno-UNOPTFLAT"
+          - "--unroll-count 72"
+
   sim:
     filesets:
       - files_rtl_base
+      - files_ibex_cpu
       - enable_relu ? (files_relu)
       - enable_vmac ? (files_vmac)
       - enable_sgdma ? (files_sgdma)
@@ -271,4 +366,47 @@ targets:
           - "--output-split 20000"
           - "--build-jobs 0"
           - '-CFLAGS "-std=c++17 -O1 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=opensoc_top_wrapper"'
+          - '-LDFLAGS "-pthread -lutil -lelf"'
+
+  sim-kronos:
+    filesets:
+      - files_rtl_base
+      - files_kronos_cpu
+      - enable_relu ? (files_relu)
+      - enable_vmac ? (files_vmac)
+      - enable_sgdma ? (files_sgdma)
+      - enable_softmax ? (files_softmax)
+      - enable_crypto ? (files_crypto)
+      - enable_conv1d ? (files_conv1d)
+      - enable_conv2d ? (files_conv2d)
+      - enable_gemm ? (files_gemm)
+      - files_lint_verilator
+      - files_sim_sv_kronos
+      - files_verilator_sim_kronos
+    toplevel: opensoc_top_wrapper
+    parameters:
+      - USE_KRONOS=true
+      - EnableReLU
+      - EnableVMAC
+      - EnableSgDma
+      - EnableSoftmax
+      - EnableCrypto
+      - EnableConv1d
+      - EnableConv2d
+      - EnableGemm
+    default_tool: verilator
+    tools:
+      verilator:
+        mode: cc
+        verilator_options:
+          - "-Wall"
+          - "-Wno-REDEFMACRO"
+          - "-Wno-SYNCASYNCNET"
+          - "-Wno-UNOPTFLAT"
+          - "--unroll-count 72"
+          - "--trace-fst"
+          - "--trace-structs"
+          - "--output-split 20000"
+          - "--build-jobs 0"
+          - '-CFLAGS "-std=c++17 -O1 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=opensoc_top_wrapper -DUSE_KRONOS"'
           - '-LDFLAGS "-pthread -lutil -lelf"'


### PR DESCRIPTION
## Summary

- Add `kronos-riscv` as a git submodule at `hw/ip/kronos_riscv` (Stage 0 single-cycle RV32I core)
- Guard Ibex CPU instantiation, ECC block, and ibex-specific config params with `ifndef USE_KRONOS`
- Add `ifdef USE_KRONOS` block to instantiate `kronos_top` instead
- Add `files_ibex_cpu` / `files_kronos_cpu` filesets and `lint-kronos`, `sim-kronos`, `synth-kronos` FuseSoC targets
- Add `CPU=ibex|kronos` Makefile variable — Ibex remains the default; `CPU=kronos` switches to Kronos

## Usage

```bash
# Lint
make lint CPU=kronos

# Simulator build (full, all IPs)
make build TOP=opensoc_top CPU=kronos

# Synthesis (Yosys/OL2 ASIC flows)
make synth FLOW=yosys CPU=kronos
```

## Test Plan

- [x] `make lint` (Ibex default) — passes, no regression
- [x] `make lint CPU=kronos` — passes clean
- [x] `make build TOP=opensoc_top CPU=kronos` — builds sim binary
- [x] `make run-hello CPU=kronos` — boots and prints Hello World