### PR TITLE
refactor: unify Kronos/Ibex FuseSoC targets behind use_kronos flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 FUSESOC        := fusesoc
-export CXX     ?= ccache g++
+CXX            ?= ccache g++
 TRACE  ?=
 WAVES  ?=
 FLOW   ?= fpga-arty
@@ -24,16 +24,13 @@ CORES_ROOT_BASE := --cores-root=. \
 
 ifeq ($(CPU),kronos)
 CORES_ROOT_BASE += --cores-root=hw/ip/kronos_riscv
-LINT_TARGET     := lint-kronos
-SIM_TARGET      := sim-kronos
-SYNTH_TARGET    := synth-kronos
-KRONOS_DEFINES  := --USE_KRONOS 1
+CPU_FLAGS       := --flag use_kronos
+CPU_DEFINES     := --USE_KRONOS 1
 else
-LINT_TARGET     := lint
-SIM_TARGET      := sim
-SYNTH_TARGET    := synth
-KRONOS_DEFINES  :=
+CPU_FLAGS       :=
+CPU_DEFINES     :=
 endif
+export CXX
 CORES_ROOT_ACCELS := --cores-root=hw/ip/relu_accel \
                      --cores-root=hw/ip/vec_mac \
                      --cores-root=hw/ip/sg_dma \
@@ -81,7 +78,11 @@ FUSESOC_DEFINES := \
   --EnableGemm $(ENABLE_GEMM)
 endif
 
+ifeq ($(CPU),kronos)
+SW_ARCH  := rv32i_zicsr
+else
 SW_ARCH  := rv32imc_zicsr_zifencei
+endif
 GTKW_DIR := dv/verilator
 
 SIM_TRACE_FLAGS := $(if $(or $(TRACE),$(WAVES)),--trace,)
@@ -157,7 +158,7 @@ help:
 	@echo ""
 	@echo "Options"
 	@echo "  CPU=ibex                    Use Ibex CPU (default)"
-	@echo "  CPU=kronos                  Use Kronos single-cycle CPU (Stage 0)"
+	@echo "  CPU=kronos                  Use Kronos CPU (adds --flag use_kronos)"
 	@echo "  TOP=opensoc_top_lean        Build lean core (default, no IPs)"
 	@echo "  TOP=opensoc_top             Build full core (use with ENABLE_* flags)"
 	@echo "  ENABLE_RELU=1               Include ReLU accelerator"
@@ -209,11 +210,15 @@ regression: $(SIM_DIR)/Vopensoc_top_wrapper
 # Full build + regression (all IPs) — used by CI
 .PHONY: build-full
 build-full:
-	$(MAKE) build $(FULL_FLAGS)
+	$(MAKE) build $(FULL_FLAGS) CPU=$(CPU)
 
 .PHONY: regression-full
 regression-full:
-	$(MAKE) regression $(FULL_FLAGS)
+	$(MAKE) regression $(FULL_FLAGS) CPU=$(CPU)
+
+# Build the simulator binary if it doesn't exist yet
+$(SIM_DIR)/Vopensoc_top_wrapper:
+	$(MAKE) build TOP=$(TOP) CPU=$(CPU)
 
 .PHONY: FORCE
 
@@ -232,13 +237,14 @@ _reg-run-%: FORCE
 
 .PHONY: lint
 lint:
-	$(FUSESOC) $(CORES_ROOT_BASE) $(CORES_ROOT_ACCELS) run --target=$(LINT_TARGET) \
+	$(FUSESOC) $(CORES_ROOT_BASE) $(CORES_ROOT_ACCELS) run --target=lint \
+	    $(CPU_FLAGS) \
 	    --flag enable_relu --flag enable_vmac --flag enable_sgdma --flag enable_softmax \
 	    --flag enable_crypto --flag enable_conv1d --flag enable_conv2d --flag enable_gemm \
 	    opensoc:soc:opensoc_top \
 	    --EnableReLU 1 --EnableVMAC 1 --EnableSgDma 1 --EnableSoftmax 1 \
 	    --EnableCrypto 1 --EnableConv1d 1 --EnableConv2d 1 --EnableGemm 1 \
-	    $(KRONOS_DEFINES)
+	    $(CPU_DEFINES)
 
 # ── Simulator build ───────────────────────────────────────────────────────────
 
@@ -253,7 +259,7 @@ build:
 	    echo "[build] $$(( (_now - _build_start) / 60 ))m elapsed..."; \
 	  done ) & \
 	_timer_pid=$$!; \
-	MAKEFLAGS="-j$(JOBS)" $(FUSESOC) $(CORES_ROOT) run --target=$(SIM_TARGET) --setup --build $(FUSESOC_FLAGS) $(BUILD_CORE_$(TOP)) $(FUSESOC_DEFINES) $(KRONOS_DEFINES); \
+	MAKEFLAGS="-j$(JOBS)" $(FUSESOC) $(CORES_ROOT) run --target=sim --setup --build $(CPU_FLAGS) $(FUSESOC_FLAGS) $(BUILD_CORE_$(TOP)) $(FUSESOC_DEFINES) $(CPU_DEFINES); \
 	kill $$_timer_pid 2>/dev/null; wait $$_timer_pid 2>/dev/null; \
 	_build_end=$$(date +%s); \
 	_elapsed=$$(( _build_end - _build_start )); \
@@ -302,12 +308,13 @@ synth-setup-asic:
 	  if [ -d "$(SYNTH_SRC_DIR_ASIC)" ]; then \
 	    echo "synth-setup-asic: completed by another process, skipping"; \
 	  else \
-	    $(FUSESOC) $(CORES_ROOT_BASE) $(CORES_ROOT_ACCELS) run --target=$(SYNTH_TARGET) --setup \
+	    $(FUSESOC) $(CORES_ROOT_BASE) $(CORES_ROOT_ACCELS) run --target=synth --setup \
+	      $(CPU_FLAGS) \
 	      --flag enable_relu --flag enable_vmac --flag enable_sgdma --flag enable_softmax \
 	      --flag enable_conv1d --flag enable_conv2d --flag enable_gemm \
 	      opensoc:soc:opensoc_top \
 	      --EnableReLU 1 --EnableVMAC 1 --EnableSgDma 1 --EnableSoftmax 1 \
-	      --EnableConv1d 1 --EnableConv2d 1 --EnableGemm 1 $(KRONOS_DEFINES); \
+	      --EnableConv1d 1 --EnableConv2d 1 --EnableGemm 1 $(CPU_DEFINES); \
 	  fi; \
 	  exec 9>&-; \
 	fi

--- a/dv/rtl/opensoc_top_wrapper.sv
+++ b/dv/rtl/opensoc_top_wrapper.sv
@@ -55,6 +55,7 @@ module opensoc_top_wrapper
   );
 
 `ifdef RVFI
+`ifndef USE_KRONOS
   ibex_tracer u_ibex_tracer (
     .clk_i                       (u_opensoc_top.clk_sys                        ),
     .rst_ni                      (u_opensoc_top.rst_sys_n                       ),
@@ -85,7 +86,8 @@ module opensoc_top_wrapper
     .rvfi_ext_expanded_insn_valid(u_opensoc_top.rvfi_ext_expanded_insn_valid    ),
     .rvfi_ext_expanded_insn      (u_opensoc_top.rvfi_ext_expanded_insn          )
   );
-`endif
+`endif  // USE_KRONOS
+`endif  // RVFI
 
 `ifndef USE_KRONOS
   export "DPI-C" function mhpmcounter_num;

--- a/dv/verilator/opensoc_top_sim.cc
+++ b/dv/verilator/opensoc_top_sim.cc
@@ -6,8 +6,9 @@
 #include <iostream>
 
 #include "Vopensoc_top_wrapper__Syms.h"
-#ifndef USE_KRONOS
+#if __has_include("ibex_pcounts.h")
 #include "ibex_pcounts.h"
+#define HAVE_IBEX_PCOUNTS 1
 #endif
 #include "opensoc_top_sim.h"
 #include "verilated_toplevel.h"
@@ -64,7 +65,7 @@ bool OpenSocSim::Finish() {
     return false;
   }
 
-#ifndef USE_KRONOS
+#ifdef HAVE_IBEX_PCOUNTS
   // Set the scope to the root scope, the ibex_pcount_string function otherwise
   // doesn't know the scope itself. Could be moved to ibex_pcount_string, but
   // would require a way to set the scope name from here, similar to MemUtil.

--- a/opensoc_top.core
+++ b/opensoc_top.core
@@ -225,7 +225,8 @@ targets:
   synth:
     filesets:
       - files_rtl_base
-      - files_ibex_cpu
+      - "!use_kronos ? (files_ibex_cpu)"
+      - use_kronos ? (files_kronos_cpu)
       - enable_relu ? (files_relu)
       - enable_vmac ? (files_vmac)
       - enable_sgdma ? (files_sgdma)
@@ -236,6 +237,7 @@ targets:
     toplevel: opensoc_top
     default_tool: verilator
     parameters:
+      - USE_KRONOS
       - EnableReLU
       - EnableVMAC
       - EnableSgDma
@@ -274,7 +276,34 @@ targets:
         mode: lint-only
 
   lint:
-    <<: *default_target
+    filesets:
+      - files_rtl_base
+      - "!use_kronos ? (files_ibex_cpu)"
+      - use_kronos ? (files_kronos_cpu)
+      - enable_relu ? (files_relu)
+      - enable_vmac ? (files_vmac)
+      - enable_sgdma ? (files_sgdma)
+      - enable_softmax ? (files_softmax)
+      - enable_crypto ? (files_crypto)
+      - enable_conv1d ? (files_conv1d)
+      - enable_conv2d ? (files_conv2d)
+      - enable_gemm ? (files_gemm)
+      - tool_verilator ? (files_lint_verilator)
+    toplevel: opensoc_top
+    parameters:
+      - USE_KRONOS
+      - RV32M
+      - RV32B
+      - RV32ZC
+      - RegFile
+      - EnableReLU
+      - EnableVMAC
+      - EnableSgDma
+      - EnableSoftmax
+      - EnableCrypto
+      - EnableConv1d
+      - EnableConv2d
+      - EnableGemm
     default_tool: verilator
     tools:
       verilator:
@@ -324,7 +353,8 @@ targets:
   sim:
     filesets:
       - files_rtl_base
-      - files_ibex_cpu
+      - "!use_kronos ? (files_ibex_cpu)"
+      - use_kronos ? (files_kronos_cpu)
       - enable_relu ? (files_relu)
       - enable_vmac ? (files_vmac)
       - enable_sgdma ? (files_sgdma)
@@ -334,11 +364,14 @@ targets:
       - enable_conv2d ? (files_conv2d)
       - enable_gemm ? (files_gemm)
       - files_lint_verilator
-      - files_sim_sv
-      - files_verilator_sim
+      - "!use_kronos ? (files_sim_sv)"
+      - use_kronos ? (files_sim_sv_kronos)
+      - "!use_kronos ? (files_verilator_sim)"
+      - use_kronos ? (files_verilator_sim_kronos)
     toplevel: opensoc_top_wrapper
     parameters:
       - RVFI=true
+      - USE_KRONOS
       - RV32M
       - RV32B
       - RV32ZC


### PR DESCRIPTION
## Summary

- Remove `lint-kronos`, `sim-kronos`, `synth-kronos` FuseSoC target variants; merge into `lint`, `sim`, `synth` using `use_kronos` flag for conditional fileset selection
- Replace `LINT_TARGET`/`SIM_TARGET`/`SYNTH_TARGET` Makefile variables with `CPU_FLAGS := --flag use_kronos`; all FuseSoC invocations now use fixed target names
- Guard `ifdef RVFI` ibex_tracer block in wrapper with `ifndef USE_KRONOS` so `RVFI=true` is safe for all builds
- Replace `#ifndef USE_KRONOS` in `opensoc_top_sim.cc` with `#if __has_include("ibex_pcounts.h")`, removing the C++ compile flag dependency entirely

## Test Plan

- [x] `make lint` passes (Ibex)
- [x] `make lint CPU=kronos` passes (Kronos)
- [x] `make build` succeeds (Ibex sim)
- [x] `make build CPU=kronos` succeeds (Kronos sim)
- [x] `make run-hello` executes correctly