### PR TITLE
feat(kronos): integrate stage2 Kronos CPU with OBI stall fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ FLOW   ?= fpga-arty
 VIVADO ?= vivado
 TOP    ?= opensoc_top_lean
 JOBS   ?= $(shell nproc)
-CPU    ?= ibex
+CPU    ?= kronos
 
 CORES_ROOT_BASE := --cores-root=. \
                    --cores-root=hw/ip/ibex \
@@ -79,7 +79,7 @@ FUSESOC_DEFINES := \
 endif
 
 ifeq ($(CPU),kronos)
-SW_ARCH  := rv32i_zicsr
+SW_ARCH  := rv32im_zicsr
 else
 SW_ARCH  := rv32imc_zicsr_zifencei
 endif
@@ -157,8 +157,8 @@ help:
 	@echo "  clean                       Remove build directory"
 	@echo ""
 	@echo "Options"
-	@echo "  CPU=ibex                    Use Ibex CPU (default)"
-	@echo "  CPU=kronos                  Use Kronos CPU (adds --flag use_kronos)"
+	@echo "  CPU=kronos                  Use Kronos CPU (default)"
+	@echo "  CPU=ibex                    Use Ibex CPU"
 	@echo "  TOP=opensoc_top_lean        Build lean core (default, no IPs)"
 	@echo "  TOP=opensoc_top             Build full core (use with ENABLE_* flags)"
 	@echo "  ENABLE_RELU=1               Include ReLU accelerator"
@@ -286,7 +286,8 @@ $(addprefix run-,$(RUN_TESTS)): run-%:
 synth:
 ifeq ($(FLOW),fpga-arty)
 	$(MAKE) synth-setup-arty
-	time $(VIVADO) -mode batch -source hw/fpga/arty_a7/synth.tcl
+	time $(VIVADO) -mode batch -source hw/fpga/arty_a7/synth.tcl \
+	  -tclargs USE_KRONOS=$(if $(filter kronos,$(CPU)),1,0)
 else ifeq ($(FLOW),yosys)
 	$(MAKE) synth-setup-asic
 	time bash hw/asic/synth.sh
@@ -330,11 +331,13 @@ synth-setup-arty:
 	  if [ -d "$(SYNTH_SRC_DIR_ARTY)" ]; then \
 	    echo "synth-setup-arty: completed by another process, skipping"; \
 	  else \
-	    $(FUSESOC) $(CORES_ROOT_BASE) $(CORES_ROOT_ACCELS) run --target=synth --setup opensoc:fpga:arty_a7 \
+	    $(FUSESOC) $(CORES_ROOT_BASE) $(CORES_ROOT_ACCELS) run --target=synth --setup \
+	      $(CPU_FLAGS) \
 	      --flag enable_relu --flag enable_vmac --flag enable_sgdma --flag enable_softmax \
 	      --flag enable_conv1d --flag enable_conv2d --flag enable_gemm \
+	      opensoc:fpga:arty_a7 \
 	      --EnableReLU 1 --EnableVMAC 1 --EnableSgDma 1 --EnableSoftmax 1 \
-	      --EnableConv1d 1 --EnableConv2d 1 --EnableGemm 1; \
+	      --EnableConv1d 1 --EnableConv2d 1 --EnableGemm 1 $(CPU_DEFINES); \
 	  fi; \
 	  exec 9>&-; \
 	fi

--- a/hw/fpga/arty_a7/synth.tcl
+++ b/hw/fpga/arty_a7/synth.tcl
@@ -64,6 +64,17 @@ create_project $PROJ_NAME $PROJ_DIR -part $PART -force
 set_property target_language Verilog [current_project]
 
 # ============================================================================
+# CPU selection — default Kronos; pass USE_KRONOS=0 via -tclargs to use Ibex
+#   make synth                  → Kronos (default)
+#   make synth CPU=ibex         → Ibex
+# ============================================================================
+set use_kronos 1
+foreach arg $argv {
+    if {$arg eq "USE_KRONOS=0"} { set use_kronos 0 }
+    if {$arg eq "USE_KRONOS=1"} { set use_kronos 1 }
+}
+
+# ============================================================================
 # Verilog defines
 # Note: FPGA_XILINX enables DSP inference in ibex_counter.
 #       FPGA_BASYS3 is intentionally NOT set — derived config pkg selects
@@ -72,6 +83,7 @@ set_property target_language Verilog [current_project]
 set VLOG_DEFINES "SYNTHESIS=1 FPGA_XILINX=1"
 append VLOG_DEFINES " RegFile=ibex_pkg::RegFileFPGA"
 append VLOG_DEFINES " PRIM_DEFAULT_IMPL=prim_pkg::ImplGeneric"
+if {$use_kronos} { append VLOG_DEFINES " USE_KRONOS=1" }
 
 set_property verilog_define $VLOG_DEFINES [current_fileset]
 
@@ -86,12 +98,23 @@ set_property include_dirs $INC_DIRS [current_fileset]
 # ============================================================================
 set PKG_FILES [read_filelist $FILELIST packages $SRC_DIR]
 
+# Kronos package (must precede Kronos RTL in elaboration order)
+if {$use_kronos} {
+    lappend PKG_FILES $SRC_DIR/opensoc_ip_kronos_riscv_0/rtl/kronos_pkg.sv
+}
+
 # ============================================================================
 # Source files — RTL (expand globs, add FPGA wrapper)
 # ============================================================================
 set rtl_patterns [read_filelist $FILELIST rtl $SRC_DIR]
 # FPGA-only: add the board wrapper
 lappend rtl_patterns $SRC_DIR/opensoc_fpga_arty_a7_0/hw/fpga/arty_a7/*.sv
+# Kronos RTL (all stages; kronos_pkg.sv is already in PKG_FILES)
+if {$use_kronos} {
+    lappend rtl_patterns $SRC_DIR/opensoc_ip_kronos_riscv_0/rtl/stage0/*.sv
+    lappend rtl_patterns $SRC_DIR/opensoc_ip_kronos_riscv_0/rtl/stage1/*.sv
+    lappend rtl_patterns $SRC_DIR/opensoc_ip_kronos_riscv_0/rtl/stage2/*.sv
+}
 
 set ALL_SV [list]
 foreach pat $rtl_patterns {

--- a/hw/lint/verilator_waiver.vlt
+++ b/hw/lint/verilator_waiver.vlt
@@ -67,6 +67,16 @@ lint_off -rule UNUSEDSIGNAL  -file "*/rtl/systolic_array.sv"
 lint_off -rule UNUSEDSIGNAL  -file "*/dv/rtl/opensoc_top_wrapper.sv"
          -match "*gpio_oe*"
 
+// AXI-Stream inter-accelerator signals: unused in lean build (no accelerators)
+lint_off -rule UNUSEDSIGNAL  -file "*/top/opensoc_top.sv"
+         -match "*relu_s_axis*"
+lint_off -rule UNUSEDSIGNAL  -file "*/top/opensoc_top.sv"
+         -match "*relu_to_smax*"
+lint_off -rule UNUSEDSIGNAL  -file "*/top/opensoc_top.sv"
+         -match "*conv2d_to_relu*"
+lint_off -rule UNUSEDSIGNAL  -file "*/top/opensoc_top.sv"
+         -match "*conv1d_to_relu*"
+
 // Dual-SoC wrapper: unused GPIO/I2C output signals
 lint_off -rule UNUSEDSIGNAL  -file "*/rtl/opensoc_dual_uart.sv"
 

--- a/hw/top/opensoc_top.sv
+++ b/hw/top/opensoc_top.sv
@@ -163,7 +163,8 @@ module opensoc_top
 
 `ifdef USE_KRONOS
   // -------------------------------------------------------------------------
-  // Kronos single-cycle RISC-V core (Stage 0 golden model)
+  // Kronos RISC-V core (OBI, uses boot_addr_i as direct initial PC)
+  // boot_addr_i = 0x20000080: Ibex adds +0x80 internally; Kronos does not.
   // -------------------------------------------------------------------------
   kronos_top u_top (
     .clk_i          (clk_sys),
@@ -185,7 +186,7 @@ module opensoc_top
     .data_err_i     (data_err),
     .irq_timer_i    (timer_irq),
     .irq_fast_i     (ibex_irq_fast),
-    .boot_addr_i    (32'h20000000)
+    .boot_addr_i    (32'h20000080)
   );
 
 `else

--- a/opensoc_fpga_arty_a7.core
+++ b/opensoc_fpga_arty_a7.core
@@ -13,6 +13,15 @@ filesets:
       - hw/fpga/arty_a7/opensoc_fpga_arty_a7_top.sv
     file_type: systemVerilogSource
 
+  # Kronos CPU — added explicitly so the use_kronos flag controls inclusion;
+  # flags do not propagate to dependencies so opensoc:soc:opensoc_top always
+  # brings Ibex along. Both CPUs are present in the Kronos build; USE_KRONOS
+  # selects the right one at elaboration; Vivado discards unreferenced modules.
+  files_kronos_cpu:
+    depend:
+      - "opensoc:ip:kronos_riscv"
+    file_type: systemVerilogSource
+
   files_constraints:
     files:
       - hw/fpga/arty_a7/arty_a7.xdc
@@ -23,6 +32,7 @@ targets:
     default_tool: vivado
     filesets:
       - files_rtl
+      - use_kronos ? (files_kronos_cpu)
       - files_constraints
     toplevel: opensoc_fpga_arty_a7_top
     tools:
@@ -32,6 +42,7 @@ targets:
       - SYNTHESIS=true
       - FPGA_XILINX=true
       - PRIM_DEFAULT_IMPL=prim_pkg::ImplGeneric
+      - USE_KRONOS
 
 parameters:
   SYNTHESIS:
@@ -49,3 +60,7 @@ parameters:
     paramtype: vlogdefine
     default: prim_pkg::ImplGeneric
     description: "Selects primitive implementation (Generic infers BRAM in Vivado)"
+  USE_KRONOS:
+    datatype: bool
+    paramtype: vlogdefine
+    description: "Select Kronos CPU instead of Ibex (default: Kronos)"

--- a/opensoc_top_lean.core
+++ b/opensoc_top_lean.core
@@ -5,10 +5,8 @@ CAPI=2:
 name: "opensoc:soc:opensoc_top_lean"
 description: "OpenSoC top-level — lean build (no accelerators, no crypto)"
 filesets:
-  files_rtl:
+  files_rtl_base:
     depend:
-      - lowrisc:ibex:ibex_top
-      - lowrisc:prim_generic:all
       - lowrisc:ibex:sim_shared
       - "pulp-platform.org::axi"
       - "opensoc:ip:pio"
@@ -21,10 +19,22 @@ filesets:
       - hw/top/opensoc_top.sv
     file_type: systemVerilogSource
 
+  files_ibex_cpu:
+    depend:
+      - lowrisc:ibex:ibex_top
+      - lowrisc:prim_generic:all
+    file_type: systemVerilogSource
+
+  files_kronos_cpu:
+    depend:
+      - "opensoc:ip:kronos_riscv"
+    file_type: systemVerilogSource
+
   files_lint_verilator:
     files:
       - hw/lint/verilator_waiver.vlt: {file_type: vlt}
 
+  # Simulation wrappers — Ibex variant includes ibex_tracer (for RVFI)
   files_sim_sv:
     depend:
       - lowrisc:ibex:ibex_tracer
@@ -32,6 +42,12 @@ filesets:
       - dv/rtl/opensoc_top_wrapper.sv
     file_type: systemVerilogSource
 
+  files_sim_sv_kronos:
+    files:
+      - dv/rtl/opensoc_top_wrapper.sv
+    file_type: systemVerilogSource
+
+  # C++ sim driver — Ibex variant includes ibex_pcounts
   files_verilator_sim:
     depend:
       - lowrisc:dv_verilator:memutil_verilator
@@ -42,10 +58,24 @@ filesets:
       - dv/verilator/opensoc_top_sim.h: {file_type: cppSource, is_include_file: true}
       - dv/verilator/opensoc_top_main.cc: {file_type: cppSource}
 
+  files_verilator_sim_kronos:
+    depend:
+      - lowrisc:dv_verilator:memutil_verilator
+      - lowrisc:dv_verilator:simutil_verilator
+    files:
+      - dv/verilator/opensoc_top_sim.cc: {file_type: cppSource}
+      - dv/verilator/opensoc_top_sim.h: {file_type: cppSource, is_include_file: true}
+      - dv/verilator/opensoc_top_main.cc: {file_type: cppSource}
+
 parameters:
   RVFI:
     datatype: bool
     paramtype: vlogdefine
+
+  USE_KRONOS:
+    datatype: bool
+    paramtype: vlogdefine
+    description: "Select Kronos CPU instead of Ibex (default: Kronos)"
 
   RV32M:
     datatype: str
@@ -70,10 +100,13 @@ parameters:
 targets:
   default: &default_target
     filesets:
-      - files_rtl
+      - files_rtl_base
+      - "!use_kronos ? (files_ibex_cpu)"
+      - use_kronos ? (files_kronos_cpu)
       - tool_verilator ? (files_lint_verilator)
     toplevel: opensoc_top
     parameters:
+      - USE_KRONOS
       - RV32M
       - RV32B
       - RV32ZC
@@ -94,13 +127,18 @@ targets:
 
   sim:
     filesets:
-      - files_rtl
+      - files_rtl_base
+      - "!use_kronos ? (files_ibex_cpu)"
+      - use_kronos ? (files_kronos_cpu)
       - files_lint_verilator
-      - files_sim_sv
-      - files_verilator_sim
+      - "!use_kronos ? (files_sim_sv)"
+      - use_kronos ? (files_sim_sv_kronos)
+      - "!use_kronos ? (files_verilator_sim)"
+      - use_kronos ? (files_verilator_sim_kronos)
     toplevel: opensoc_top_wrapper
     parameters:
       - RVFI=true
+      - USE_KRONOS
       - RV32M
       - RV32B
       - RV32ZC


### PR DESCRIPTION
## Summary

- Bumps `kronos-riscv` submodule to stage2 (RV32IM, 5-stage in-order pipeline)
- Fixes three integration bugs that caused all `CPU=kronos` tests to time out
- Makes Kronos the default CPU everywhere: simulation, synthesis, P&R
- Updates `opensoc_top_lean.core` with `use_kronos` flag support
- Adds Kronos support to FPGA core (`opensoc_fpga_arty_a7.core`): `USE_KRONOS=1` in Vivado defines; Vivado discards the unreferenced Ibex modules
- Fixes lean build: waivers for unused AXI-Stream accel pipeline signals

Verified: 16/16 regression tests pass, Vivado bitstream generated successfully.

## Root causes fixed

**Boot address** (`opensoc_top.sv`): Ibex adds `+0x80` to `boot_addr_i` internally; Kronos uses the supplied address directly. Changed to `32'h20000080`.

**Duplicate instruction fetch** (`kronos_top` stage2): `CUT_ALL_PORTS` introduces multi-cycle fetch latency. Without a fetch-throttle, the MaxRequests=2 bridge accepted a second fetch for the same frozen PC. Added `fetch_outstanding` + `instr_fetch_stall` to freeze `pc_q` until `instr_rvalid_i` arrives.

**LSU infinite re-issue** (`kronos_lsu` + `kronos_top` stage2): `instr_fetch_stall` kept `combined_stall=1` after data rvalid arrived, causing the LSU to re-issue the same request in an infinite loop. Fixed by:
- Gating `data_req_o=0` in `WAIT_RVALID` state (LSU)
- Adding `mem_done_q` to suppress LSU req until the pipeline advances, plus `lsu_rdata_latch` to preserve load data across the stall gap

## FPGA flag propagation note

FuseSoC flags do not propagate through the dependency chain. `opensoc:fpga:arty_a7` depends on `opensoc:soc:opensoc_top`, which always pulls in Ibex. The fix adds `files_kronos_cpu` directly to the FPGA core with `use_kronos ? (files_kronos_cpu)`, so both CPUs are present in the Kronos build. `USE_KRONOS=1` in the Vivado defines selects Kronos at elaboration; Vivado optimizes away the unreferenced Ibex hierarchy.