### PR TITLE
feat(kronos): bump to v0.5.2 (stage5 RV64IMAFD + Vivado synthesis)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ tight_setup_hold_pins.txt
 vivado*.jou
 vivado*.log
 clockInfo.txt
+iter_*CongestedCLBsAndNets.txt

--- a/dv/verilator/opensoc_top_sim.cc
+++ b/dv/verilator/opensoc_top_sim.cc
@@ -10,6 +10,13 @@
 #include "verilator_memutil.h"
 #include "verilator_sim_ctrl.h"
 
+// DPI-C implementation for simulator_ctrl.sv: dpi_sim_finish(int unsigned).
+// Called from RTL when the SW test writes to SIM_CTRL_CTRL.
+// failures == 0  → simulation succeeded; failures > 0 → test reported errors.
+extern "C" void dpi_sim_finish(unsigned int failures) {
+  VerilatorSimCtrl::GetInstance().RequestStop(failures == 0);
+}
+
 OpenSocSim::OpenSocSim(const char *ram_hier_path, int ram_size_words)
     : _ram(ram_hier_path, ram_size_words, 4) {}
 

--- a/hw/asic/synth.sh
+++ b/hw/asic/synth.sh
@@ -24,21 +24,48 @@ if [ ! -d "$SRC_DIR" ]; then
 fi
 
 # ============================================================================
-# Read shared filelist (sections: includes, packages, rtl)
+# Read shared filelist (sections: includes, packages, [kronos], rtl)
 # ============================================================================
+
+# Parse one [section] from a filelist file, emit each entry prefixed with root/.
+_parse_section() {
+    local file="$1" section="$2" prefix="$3"
+    local in=0
+    while IFS= read -r line; do
+        line="${line%%#*}"
+        line="${line#"${line%%[![:space:]]*}"}"
+        line="${line%"${line##*[![:space:]]}"}"
+        [[ -z "$line" ]] && continue
+        if [[ "$line" =~ ^\[(.+)\]$ ]]; then
+            [[ "${BASH_REMATCH[1]}" == "$section" ]] && in=1 || in=0
+            continue
+        fi
+        [[ $in -eq 1 ]] && echo "${prefix}/${line}"
+    done < "$file"
+}
+
+# Read [section] from $FILELIST.  [kronos] entries are expanded by reading the
+# referenced per-stage filelist from the kronos-riscv submodule.  Output lines
+# are paths relative to $SRC_DIR (callers prepend $SRC_DIR/ when needed).
 read_filelist() {
     local section="$1"
     local in_section=0
+    local in_kronos=0
     while IFS= read -r line; do
-        line="${line%%#*}"          # strip comments
-        line="${line#"${line%%[![:space:]]*}"}"  # trim leading whitespace
-        line="${line%"${line##*[![:space:]]}"}"  # trim trailing whitespace
+        line="${line%%#*}"
+        line="${line#"${line%%[![:space:]]*}"}"
+        line="${line%"${line##*[![:space:]]}"}"
         [[ -z "$line" ]] && continue
         if [[ "$line" =~ ^\[(.+)\]$ ]]; then
             [[ "${BASH_REMATCH[1]}" == "$section" ]] && in_section=1 || in_section=0
+            [[ "${BASH_REMATCH[1]}" == "kronos"   ]] && in_kronos=1  || in_kronos=0
             continue
         fi
-        [[ $in_section -eq 1 ]] && echo "$line"
+        if   [[ $in_section -eq 1 ]]; then
+            echo "$line"
+        elif [[ $in_kronos  -eq 1 ]]; then
+            _parse_section "$SRC_DIR/$line" "$section" "$(dirname "$line")"
+        fi
     done < "$FILELIST"
 }
 

--- a/hw/fpga/arty_a7/synth.tcl
+++ b/hw/fpga/arty_a7/synth.tcl
@@ -43,7 +43,6 @@ proc read_filelist {filepath section prefix} {
     set result [list]
     set fd [open $filepath r]
     while {[gets $fd line] >= 0} {
-        # Strip comments and trim
         regsub {#.*$} $line {} line
         set line [string trim $line]
         if {$line eq ""} continue
@@ -82,8 +81,7 @@ set_property include_dirs $INC_DIRS [current_fileset]
 # Source files — packages first (order matters for elaboration)
 # ============================================================================
 set PKG_FILES [read_filelist $FILELIST packages $SRC_DIR]
-
-# Kronos package (must precede Kronos RTL in elaboration order)
+# Kronos package must precede Kronos RTL in elaboration order
 lappend PKG_FILES $SRC_DIR/opensoc_ip_kronos_riscv_0/rtl/kronos_pkg.sv
 
 # ============================================================================
@@ -92,11 +90,6 @@ lappend PKG_FILES $SRC_DIR/opensoc_ip_kronos_riscv_0/rtl/kronos_pkg.sv
 set rtl_patterns [read_filelist $FILELIST rtl $SRC_DIR]
 # FPGA-only: add the board wrapper
 lappend rtl_patterns $SRC_DIR/opensoc_fpga_arty_a7_0/hw/fpga/arty_a7/*.sv
-# Kronos RTL (all stages; kronos_pkg.sv is already in PKG_FILES)
-lappend rtl_patterns $SRC_DIR/opensoc_ip_kronos_riscv_0/rtl/stage0/*.sv
-lappend rtl_patterns $SRC_DIR/opensoc_ip_kronos_riscv_0/rtl/stage1/*.sv
-lappend rtl_patterns $SRC_DIR/opensoc_ip_kronos_riscv_0/rtl/stage2/*.sv
-lappend rtl_patterns $SRC_DIR/opensoc_ip_kronos_riscv_0/rtl/stage3/*.sv
 lappend rtl_patterns $SRC_DIR/opensoc_ip_sim_shared_0/*.sv
 
 set ALL_SV [list]

--- a/hw/fpga/kv260/synth.tcl
+++ b/hw/fpga/kv260/synth.tcl
@@ -49,7 +49,6 @@ proc read_filelist {filepath section prefix} {
     set result [list]
     set fd [open $filepath r]
     while {[gets $fd line] >= 0} {
-        # Strip comments and trim
         regsub {#.*$} $line {} line
         set line [string trim $line]
         if {$line eq ""} continue
@@ -109,8 +108,7 @@ set_property include_dirs $INC_DIRS [current_fileset]
 # Source files — packages first (order matters for elaboration)
 # ============================================================================
 set PKG_FILES [read_filelist $FILELIST packages $SRC_DIR]
-
-# Kronos package (must precede Kronos RTL in elaboration order)
+# Kronos package must precede Kronos RTL in elaboration order
 lappend PKG_FILES $SRC_DIR/opensoc_ip_kronos_riscv_0/rtl/kronos_pkg.sv
 
 # ============================================================================
@@ -119,11 +117,6 @@ lappend PKG_FILES $SRC_DIR/opensoc_ip_kronos_riscv_0/rtl/kronos_pkg.sv
 set rtl_patterns [read_filelist $FILELIST rtl $SRC_DIR]
 # FPGA-only: add the board wrapper
 lappend rtl_patterns $SRC_DIR/opensoc_fpga_kv260_0/hw/fpga/kv260/*.sv
-# Kronos RTL (all stages; kronos_pkg.sv is already in PKG_FILES)
-lappend rtl_patterns $SRC_DIR/opensoc_ip_kronos_riscv_0/rtl/stage0/*.sv
-lappend rtl_patterns $SRC_DIR/opensoc_ip_kronos_riscv_0/rtl/stage1/*.sv
-lappend rtl_patterns $SRC_DIR/opensoc_ip_kronos_riscv_0/rtl/stage2/*.sv
-lappend rtl_patterns $SRC_DIR/opensoc_ip_kronos_riscv_0/rtl/stage3/*.sv
 lappend rtl_patterns $SRC_DIR/opensoc_ip_sim_shared_0/*.sv
 
 set ALL_SV [list]

--- a/hw/ip/dv_verilator/simutil_verilator/cpp/verilator_sim_ctrl.cc
+++ b/hw/ip/dv_verilator/simutil_verilator/cpp/verilator_sim_ctrl.cc
@@ -391,6 +391,7 @@ void VerilatorSimCtrl::Run() {
     if (term_after_cycles_ && (time_ / 2 >= term_after_cycles_)) {
       std::cout << "Simulation timeout of " << term_after_cycles_
                 << " cycles reached, shutting down simulation." << std::endl;
+      simulation_success_ = false;
       break;
     }
   }

--- a/hw/ip/sim/simulator_ctrl.sv
+++ b/hw/ip/sim/simulator_ctrl.sv
@@ -11,7 +11,9 @@
  * * 0x0 - CHAR_OUT_ADDR - [7:0] of write data output via output_char DPI call
  * and SimOutputManager (see dv/common/cpp/sim_output_manager.cc)
  *
- * * 0x8 - SIM_CTRL_ADDR - Write 1 to bit 0 to halt sim
+ * * 0x8 - SIM_CTRL_ADDR - Write to halt sim.
+ *   bit  [0]    : halt trigger (must be 1)
+ *   bits [31:1] : failure count (0 = pass, >0 = fail)
  *
  * The slightly odd spacing is because we also use SIM_CTRL_ADDR when
  * simulating simple_system code with Spike, which requires the address to be
@@ -38,11 +40,16 @@ module simulator_ctrl #(
   output logic [31:0] rdata_o
 );
 
+  // Propagate failure count to the Verilator C++ harness via DPI.
+  // The harness sets simulation_success accordingly before exiting.
+  import "DPI-C" function void dpi_sim_finish(int unsigned failures);
+
   localparam logic [7:0] CHAR_OUT_ADDR = 8'h0;
   localparam logic [7:0] SIM_CTRL_ADDR = 8'h2;
 
-  logic [7:0] ctrl_addr;
-  logic [2:0] sim_finish;
+  logic [7:0]  ctrl_addr;
+  logic [2:0]  sim_finish;
+  logic [30:0] fail_count_q;
 
   integer log_fd;
 
@@ -58,8 +65,9 @@ module simulator_ctrl #(
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (~rst_ni) begin
-      rvalid_o <= 0;
-      sim_finish <= 'b0;
+      rvalid_o    <= 0;
+      sim_finish  <= 'b0;
+      fail_count_q <= '0;
     end else begin
       // Immediately respond to any request
       rvalid_o <= req_i;
@@ -78,7 +86,8 @@ module simulator_ctrl #(
           SIM_CTRL_ADDR: begin
             if ((be_i[0] & wdata_i[0]) && (sim_finish == 'b0)) begin
               $display("Terminating simulation by software request.");
-              sim_finish <= 3'b001;
+              fail_count_q <= wdata_i[31:1];
+              sim_finish   <= 3'b001;
             end
           end
           default: ;
@@ -90,7 +99,7 @@ module simulator_ctrl #(
       sim_finish <= sim_finish + 1;
     end
     if (sim_finish >= 3'b010) begin
-      $finish;
+      dpi_sim_finish({1'b0, fail_count_q});
     end
   end
 

--- a/hw/synth/sources.f
+++ b/hw/synth/sources.f
@@ -21,18 +21,31 @@ opensoc_soc_opensoc_top_0/hw/top/opensoc_config_pkg.sv
 opensoc_soc_opensoc_top_0/hw/top/opensoc_derived_config_pkg.sv
 
 [rtl]
+# Kronos stage5 (RV64IMAFD)
 opensoc_ip_kronos_riscv_0/rtl/kronos_pkg.sv
-# Kronos modules used by stage3: alu/regfile/csr from stage0, forward/hazard
-# from stage1, decode/muldiv from stage2, everything else from stage3.
-# Stage0/1/2 kronos_top.sv and kronos_lsu.sv are excluded to avoid duplicates.
-opensoc_ip_kronos_riscv_0/rtl/stage0/kronos_alu.sv
 opensoc_ip_kronos_riscv_0/rtl/stage0/kronos_regfile.sv
-opensoc_ip_kronos_riscv_0/rtl/stage0/kronos_csr.sv
 opensoc_ip_kronos_riscv_0/rtl/stage1/kronos_forward.sv
 opensoc_ip_kronos_riscv_0/rtl/stage1/kronos_hazard.sv
-opensoc_ip_kronos_riscv_0/rtl/stage2/kronos_decode.sv
-opensoc_ip_kronos_riscv_0/rtl/stage2/kronos_muldiv.sv
-opensoc_ip_kronos_riscv_0/rtl/stage3/*.sv
+opensoc_ip_kronos_riscv_0/rtl/stage3/kronos_align.sv
+opensoc_ip_kronos_riscv_0/rtl/stage3/kronos_bpred.sv
+opensoc_ip_kronos_riscv_0/rtl/stage5/kronos_alu.sv
+opensoc_ip_kronos_riscv_0/rtl/stage5/kronos_decode.sv
+opensoc_ip_kronos_riscv_0/rtl/stage5/kronos_regfile_fp.sv
+opensoc_ip_kronos_riscv_0/rtl/stage5/kronos_csr.sv
+opensoc_ip_kronos_riscv_0/rtl/stage5/kronos_lsu.sv
+opensoc_ip_kronos_riscv_0/rtl/stage5/kronos_muldiv.sv
+opensoc_ip_kronos_riscv_0/rtl/stage5/kronos_decompress.sv
+opensoc_ip_kronos_riscv_0/rtl/stage5/fpu/kronos_fpu_scoreboard.sv
+opensoc_ip_kronos_riscv_0/rtl/stage5/fpu/kronos_fpu_fmisc.sv
+opensoc_ip_kronos_riscv_0/rtl/stage5/fpu/kronos_fpu_fcvt.sv
+opensoc_ip_kronos_riscv_0/rtl/stage5/fpu/kronos_fpu_fadd.sv
+opensoc_ip_kronos_riscv_0/rtl/stage5/fpu/kronos_fpu_fmul.sv
+opensoc_ip_kronos_riscv_0/rtl/stage5/fpu/kronos_fpu_fma.sv
+opensoc_ip_kronos_riscv_0/rtl/stage5/fpu/kronos_fpu_fdiv_core.sv
+opensoc_ip_kronos_riscv_0/rtl/stage5/fpu/kronos_fpu_fsqrt_core.sv
+opensoc_ip_kronos_riscv_0/rtl/stage5/fpu/kronos_fpu_iter.sv
+opensoc_ip_kronos_riscv_0/rtl/stage5/fpu/kronos_fpu_top.sv
+opensoc_ip_kronos_riscv_0/rtl/stage5/kronos_top.sv
 opensoc_ip_sim_shared_0/*.sv
 pulp-platform.org__axi_0.39.9/src/*.sv
 pulp-platform.org__common_cells_1.39.0/src/*.sv

--- a/sw/common/crt0.S
+++ b/sw/common/crt0.S
@@ -82,10 +82,13 @@ main_entry:
   addi x11, x0, 0
   jal x1, main
 
-  /* Halt simulation */
-  li x5, SIM_CTRL_BASE + SIM_CTRL_CTRL
-  li x6, 1
-  sw x6, 0(x5)
+  /* Halt simulation, propagating main()'s return value as the failure count.
+     SIM_CTRL_CTRL encoding: bit[0]=halt trigger, bits[31:1]=failure count.
+     a0 (x10) holds main()'s return value: 0=pass, >0=number of failures. */
+  slli x6, x10, 1           /* x6 = failures << 1                   */
+  ori  x6, x6,  1           /* x6 = (failures << 1) | halt_trigger  */
+  li   x5, SIM_CTRL_BASE + SIM_CTRL_CTRL
+  sw   x6, 0(x5)
 
   /* If execution ends up here put the core to sleep */
 sleep_loop:

--- a/sw/common/simple_system_common.c
+++ b/sw/common/simple_system_common.c
@@ -48,7 +48,10 @@ void puthex64(uint64_t h) {
   }
 }
 
-void sim_halt() { DEV_WRITE(SIM_CTRL_BASE + SIM_CTRL_CTRL, 1); }
+void sim_halt(uint32_t failures) {
+  // SIM_CTRL_CTRL encoding: bit[0]=halt trigger, bits[31:1]=failure count.
+  DEV_WRITE(SIM_CTRL_BASE + SIM_CTRL_CTRL, (failures << 1) | 1u);
+}
 
 void pcount_reset() {
   asm volatile(
@@ -113,7 +116,7 @@ void simple_exc_handler(void) {
   puts("\nMTVAL:  0x");
   puthex64(get_mtval());
   putchar('\n');
-  sim_halt();
+  sim_halt(1);
 
   while(1);
 }

--- a/sw/common/simple_system_common.h
+++ b/sw/common/simple_system_common.h
@@ -43,9 +43,13 @@ uint64_t get_mcause(void);
 uint64_t get_mtval(void);
 
 /**
- * Immediately halts the simulation
+ * Halts the simulation.
+ *
+ * @param failures Number of test failures (0 = pass, >0 = fail).
+ *                 Encoded as bits[31:1] of the SIM_CTRL_CTRL write;
+ *                 bit[0] is the halt trigger.
  */
-void sim_halt();
+void sim_halt(uint32_t failures);
 
 /**
  * Enables/disables performance counters.  This effects mcycle and minstret as

--- a/sw/tests/conv1d_relu_stream_test/conv1d_relu_stream_test.c
+++ b/sw/tests/conv1d_relu_stream_test/conv1d_relu_stream_test.c
@@ -113,7 +113,7 @@ static void stream_run(uint32_t conv1d_src, uint32_t relu_dst,
     ;
   if (!(DEV_READ(RELU_STATUS, 0) & RELU_STATUS_DONE)) {
     puts("TIMEOUT: stream pipeline did not complete\n");
-    return 1;
+    return;
   }
 }
 
@@ -194,7 +194,7 @@ int main(int argc, char **argv) {
 
     DEV_WRITE(CONV1D_CTRL, CONV1D_CTRL_SOFT_RESET);
 
-    stream_run((uint32_t)sig_a, (uint32_t)out_a,
+    stream_run((uint32_t)(uintptr_t)sig_a, (uint32_t)(uintptr_t)out_a,
                IN_LEN_A, KSIZE_A, CONV1D_PAD_VALID, k3);
 
     int t1_err = 0;
@@ -231,7 +231,7 @@ int main(int argc, char **argv) {
 
     DEV_WRITE(CONV1D_CTRL, CONV1D_CTRL_SOFT_RESET);
 
-    stream_run((uint32_t)sig_b, (uint32_t)out_b,
+    stream_run((uint32_t)(uintptr_t)sig_b, (uint32_t)(uintptr_t)out_b,
                IN_LEN_B, KSIZE_A, CONV1D_PAD_SAME, k3);
 
     // All outputs must be zero (all inputs negative, conv outputs negative)
@@ -279,7 +279,7 @@ int main(int argc, char **argv) {
 
     pcount_reset();
     pcount_enable(1);
-    stream_run((uint32_t)sig_c, (uint32_t)out_c,
+    stream_run((uint32_t)(uintptr_t)sig_c, (uint32_t)(uintptr_t)out_c,
                IN_LEN_C, KSIZE_C, CONV1D_PAD_VALID, k5);
     pcount_enable(0);
     uint32_t cyc_stream;
@@ -311,9 +311,9 @@ int main(int argc, char **argv) {
 
     pcount_reset();
     pcount_enable(1);
-    conv1d_dma_run((uint32_t)sig_c, (uint32_t)mid_c,
+    conv1d_dma_run((uint32_t)(uintptr_t)sig_c, (uint32_t)(uintptr_t)mid_c,
                    IN_LEN_C, KSIZE_C, CONV1D_PAD_VALID, k5);
-    relu_dma_run((uint32_t)mid_c, (uint32_t)out_c, OUT_LEN_C);
+    relu_dma_run((uint32_t)(uintptr_t)mid_c, (uint32_t)(uintptr_t)out_c, OUT_LEN_C);
     pcount_enable(0);
     uint32_t cyc_dma;
     PCOUNT_READ(mcycle, cyc_dma);
@@ -356,5 +356,5 @@ int main(int argc, char **argv) {
     puts("TESTS FAILED: "); putdec((uint32_t)errors); puts(" error(s)\n");
   }
 
-  return 0;
+  return errors;
 }

--- a/sw/tests/conv1d_test/conv1d_test.c
+++ b/sw/tests/conv1d_test/conv1d_test.c
@@ -198,7 +198,7 @@ int main(int argc, char **argv) {
 
   ref_conv_valid(signal_a, IN_LEN, kernel, KSIZE, ref_a);
 
-  conv1d_run((uint32_t)signal_a, (uint32_t)output_a, IN_LEN,
+  conv1d_run((uint32_t)(uintptr_t)signal_a, (uint32_t)(uintptr_t)output_a, IN_LEN,
              KSIZE, CONV1D_PAD_VALID, kernel);
 
   status = DEV_READ(CONV1D_STATUS, 0);
@@ -238,7 +238,7 @@ int main(int argc, char **argv) {
 
   DEV_WRITE(CONV1D_CTRL, CONV1D_CTRL_SOFT_RESET);
 
-  conv1d_run((uint32_t)signal_b, (uint32_t)output_b, IN_LEN_B,
+  conv1d_run((uint32_t)(uintptr_t)signal_b, (uint32_t)(uintptr_t)output_b, IN_LEN_B,
              KSIZE, CONV1D_PAD_SAME, kernel);
 
   int t2_err = 0;
@@ -269,7 +269,7 @@ int main(int argc, char **argv) {
     for (int i = 0; i < IN_LEN; i++) output_a[i] = 0;
     ref_conv_valid(signal_a, IN_LEN, k5, 5, ref_a);
     DEV_WRITE(CONV1D_CTRL, CONV1D_CTRL_SOFT_RESET);
-    conv1d_run((uint32_t)signal_a, (uint32_t)output_a, IN_LEN, 5, CONV1D_PAD_VALID, k5);
+    conv1d_run((uint32_t)(uintptr_t)signal_a, (uint32_t)(uintptr_t)output_a, IN_LEN, 5, CONV1D_PAD_VALID, k5);
     int t3_err = 0;
     for (int n = 0; n < olen; n++) {
       if (output_a[n] != ref_a[n]) {
@@ -295,7 +295,7 @@ int main(int argc, char **argv) {
     for (int i = 0; i < IN_LEN; i++) output_a[i] = 0;
     ref_conv_valid(signal_a, IN_LEN, k7, 7, ref_a);
     DEV_WRITE(CONV1D_CTRL, CONV1D_CTRL_SOFT_RESET);
-    conv1d_run((uint32_t)signal_a, (uint32_t)output_a, IN_LEN, 7, CONV1D_PAD_VALID, k7);
+    conv1d_run((uint32_t)(uintptr_t)signal_a, (uint32_t)(uintptr_t)output_a, IN_LEN, 7, CONV1D_PAD_VALID, k7);
     int t4_err = 0;
     for (int n = 0; n < olen; n++) {
       if (output_a[n] != ref_a[n]) {
@@ -321,7 +321,7 @@ int main(int argc, char **argv) {
     for (int i = 0; i < IN_LEN_B; i++) output_b[i] = 0;
     ref_conv_valid(signal_b, IN_LEN_B, k1, 1, ref_b);
     DEV_WRITE(CONV1D_CTRL, CONV1D_CTRL_SOFT_RESET);
-    conv1d_run((uint32_t)signal_b, (uint32_t)output_b, IN_LEN_B, 1, CONV1D_PAD_VALID, k1);
+    conv1d_run((uint32_t)(uintptr_t)signal_b, (uint32_t)(uintptr_t)output_b, IN_LEN_B, 1, CONV1D_PAD_VALID, k1);
     int t5_err = 0;
     for (int n = 0; n < IN_LEN_B; n++) {
       if (output_b[n] != ref_b[n]) {
@@ -350,7 +350,7 @@ int main(int argc, char **argv) {
 
     pcount_reset();
     pcount_enable(1);
-    conv1d_run((uint32_t)signal_c, (uint32_t)output_c, IN_LEN_C, 5, CONV1D_PAD_VALID, k5t);
+    conv1d_run((uint32_t)(uintptr_t)signal_c, (uint32_t)(uintptr_t)output_c, IN_LEN_C, 5, CONV1D_PAD_VALID, k5t);
     pcount_enable(0);
     uint32_t cyc;
     PCOUNT_READ(mcycle, cyc);
@@ -386,5 +386,5 @@ int main(int argc, char **argv) {
     puts("TESTS FAILED: "); putdec((uint32_t)errors); puts(" error(s)\n");
   }
 
-  return 0;
+  return errors;
 }

--- a/sw/tests/conv2d_relu_softmax_stream_test/conv2d_relu_softmax_stream_test.c
+++ b/sw/tests/conv2d_relu_softmax_stream_test/conv2d_relu_softmax_stream_test.c
@@ -52,11 +52,6 @@ static void putdec(uint32_t v) {
   while (pos > 0) putchar(buf[--pos]);
 }
 
-static void put_i32(int32_t v) {
-  if (v < 0) { putchar('-'); putdec((uint32_t)(-v)); }
-  else putdec((uint32_t)v);
-}
-
 // ---------------------------------------------------------------------------
 // exp LUT (must match hardware exp_lut.sv, scale=46)
 // ---------------------------------------------------------------------------
@@ -254,7 +249,7 @@ int main(int argc, char **argv) {
     // Reset Conv2D
     DEV_WRITE(CONV2D_CTRL, CONV2D_CTRL_SOFT_RESET);
 
-    stream_run((uint32_t)img_buf, (uint32_t)smax_out,
+    stream_run((uint32_t)(uintptr_t)img_buf, (uint32_t)(uintptr_t)smax_out,
                IMG_W, IMG_H, k_id, VEC_LEN);
 
     if (!(DEV_READ(SMAX_STATUS, 0) & SMAX_STATUS_DONE)) {
@@ -306,7 +301,7 @@ int main(int argc, char **argv) {
 
     for (int i = 0; i < (int)((N_OUT+3)/4); i++) smax_out[i] = 0xDEADBEEFu;
     DEV_WRITE(CONV2D_CTRL, CONV2D_CTRL_SOFT_RESET);
-    stream_run((uint32_t)img_buf, (uint32_t)smax_out,
+    stream_run((uint32_t)(uintptr_t)img_buf, (uint32_t)(uintptr_t)smax_out,
                IMG_W, IMG_H, k_sm, VEC_LEN);
 
     if (!(DEV_READ(SMAX_STATUS, 0) & SMAX_STATUS_DONE)) {
@@ -353,7 +348,7 @@ int main(int argc, char **argv) {
     // --- (a) Stream pipeline ---
     pcount_reset();
     pcount_enable(1);
-    stream_run((uint32_t)img_buf, (uint32_t)smax_out,
+    stream_run((uint32_t)(uintptr_t)img_buf, (uint32_t)(uintptr_t)smax_out,
                IMG_W, IMG_H, k_id, VEC_LEN);
     pcount_enable(0);
     uint32_t cyc_stream;
@@ -368,13 +363,13 @@ int main(int argc, char **argv) {
 
     pcount_reset();
     pcount_enable(1);
-    conv2d_dma_run((uint32_t)img_buf, (uint32_t)conv2d_out,
+    conv2d_dma_run((uint32_t)(uintptr_t)img_buf, (uint32_t)(uintptr_t)conv2d_out,
                    IMG_W, IMG_H, k_id);
-    relu_dma_run((uint32_t)conv2d_out, (uint32_t)relu_out, N_OUT);
+    relu_dma_run((uint32_t)(uintptr_t)conv2d_out, (uint32_t)(uintptr_t)relu_out, N_OUT);
     // Softmax expects INT8 packed 4/word; relu_out is INT32. For DMA-only
     // path we pass relu_out reinterpreted as bytes — valid for identity kernel
     // since values fit in INT8 (bits[7:0] = value).
-    smax_dma_run((uint32_t)relu_out, (uint32_t)smax_out, VEC_LEN);
+    smax_dma_run((uint32_t)(uintptr_t)relu_out, (uint32_t)(uintptr_t)smax_out, VEC_LEN);
     pcount_enable(0);
     uint32_t cyc_dma;
     PCOUNT_READ(mcycle, cyc_dma);
@@ -406,5 +401,5 @@ int main(int argc, char **argv) {
     puts("TESTS FAILED: "); putdec((uint32_t)errors); puts(" error(s)\n");
   }
 
-  return 0;
+  return errors;
 }

--- a/sw/tests/conv2d_test/conv2d_test.c
+++ b/sw/tests/conv2d_test/conv2d_test.c
@@ -195,7 +195,7 @@ int main(int argc, char **argv) {
   puts("--- Test 1: Valid, identity, 8x8 ---\n");
   {
     for (int i = 0; i < 64; i++) img8[i] = (int32_t)(int8_t)((i * 3 + 7) & 0x7F);
-    conv2d_run((uint32_t)img8, (uint32_t)out_buf, 8, 8, CONV2D_PAD_VALID, identity);
+    conv2d_run((uint32_t)(uintptr_t)img8, (uint32_t)(uintptr_t)out_buf, 8, 8, CONV2D_PAD_VALID, identity);
     // identity kernel: output[r][c] = img[(r+1)*8 + (c+1)]
     for (int r = 0; r < 6; r++)
       for (int c = 0; c < 6; c++)
@@ -209,7 +209,7 @@ int main(int argc, char **argv) {
   puts("--- Test 2: Valid, edge kernel, 8x8 ---\n");
   {
     for (int i = 0; i < 64; i++) img8[i] = (int32_t)(int8_t)(i & 0x7F);
-    conv2d_run((uint32_t)img8, (uint32_t)out_buf, 8, 8, CONV2D_PAD_VALID, edge);
+    conv2d_run((uint32_t)(uintptr_t)img8, (uint32_t)(uintptr_t)out_buf, 8, 8, CONV2D_PAD_VALID, edge);
     conv2d_ref_valid(img8, 8, 8, edge, ref_buf);
     errors += check(out_buf, ref_buf, 36, "Valid edge 8x8");
   }
@@ -220,7 +220,7 @@ int main(int argc, char **argv) {
   puts("--- Test 3: Valid, smooth [1,2,1;2,4,2;1,2,1], 8x8 ---\n");
   {
     for (int i = 0; i < 64; i++) img8[i] = (int32_t)(int8_t)((i * 5 + 3) & 0x3F);
-    conv2d_run((uint32_t)img8, (uint32_t)out_buf, 8, 8, CONV2D_PAD_VALID, smooth);
+    conv2d_run((uint32_t)(uintptr_t)img8, (uint32_t)(uintptr_t)out_buf, 8, 8, CONV2D_PAD_VALID, smooth);
     conv2d_ref_valid(img8, 8, 8, smooth, ref_buf);
     errors += check(out_buf, ref_buf, 36, "Valid smooth 8x8");
   }
@@ -231,7 +231,7 @@ int main(int argc, char **argv) {
   puts("--- Test 4: Valid, smooth, 16x16 ---\n");
   {
     for (int i = 0; i < 256; i++) img16[i] = (int32_t)(int8_t)((i * 3 + 1) & 0x3F);
-    conv2d_run((uint32_t)img16, (uint32_t)out_buf, 16, 16, CONV2D_PAD_VALID, smooth);
+    conv2d_run((uint32_t)(uintptr_t)img16, (uint32_t)(uintptr_t)out_buf, 16, 16, CONV2D_PAD_VALID, smooth);
     conv2d_ref_valid(img16, 16, 16, smooth, ref_buf);
     errors += check(out_buf, ref_buf, 14*14, "Valid smooth 16x16");
   }
@@ -243,7 +243,7 @@ int main(int argc, char **argv) {
   {
     for (int i = 0; i < 1024; i++) img32[i] = (int32_t)(int8_t)((i * 7 + 2) & 0x3F);
     // Warm run for correctness (no timing)
-    conv2d_run((uint32_t)img32, (uint32_t)out_buf, 32, 32, CONV2D_PAD_VALID, smooth);
+    conv2d_run((uint32_t)(uintptr_t)img32, (uint32_t)(uintptr_t)out_buf, 32, 32, CONV2D_PAD_VALID, smooth);
     conv2d_ref_valid(img32, 32, 32, smooth, ref_buf);
     errors += check(out_buf, ref_buf, 30*30, "Valid smooth 32x32");
 
@@ -255,8 +255,8 @@ int main(int argc, char **argv) {
     DEV_WRITE(CONV2D_IMG_HEIGHT,   32);
     DEV_WRITE(CONV2D_KERNEL_SIZE,   3);
     DEV_WRITE(CONV2D_PADDING_MODE, CONV2D_PAD_VALID);
-    DEV_WRITE(CONV2D_SRC_ADDR, (uint32_t)img32);
-    DEV_WRITE(CONV2D_DST_ADDR, (uint32_t)out_buf);
+    DEV_WRITE(CONV2D_SRC_ADDR, (uint32_t)(uintptr_t)img32);
+    DEV_WRITE(CONV2D_DST_ADDR, (uint32_t)(uintptr_t)out_buf);
 
     pcount_reset();
     pcount_enable(1);
@@ -282,7 +282,7 @@ int main(int argc, char **argv) {
   puts("--- Test 6: Same, identity, 8x8 ---\n");
   {
     for (int i = 0; i < 64; i++) img8[i] = (int32_t)(int8_t)((i * 3 + 7) & 0x7F);
-    conv2d_run((uint32_t)img8, (uint32_t)out_buf, 8, 8, CONV2D_PAD_SAME, identity);
+    conv2d_run((uint32_t)(uintptr_t)img8, (uint32_t)(uintptr_t)out_buf, 8, 8, CONV2D_PAD_SAME, identity);
     for (int i = 0; i < 64; i++)
       ref_buf[i] = (int32_t)(int8_t)(img8[i] & 0xFF);
     errors += check(out_buf, ref_buf, 64, "Same identity 8x8");
@@ -294,7 +294,7 @@ int main(int argc, char **argv) {
   puts("--- Test 7: Same, smooth, 8x8 ---\n");
   {
     for (int i = 0; i < 64; i++) img8[i] = (int32_t)(int8_t)((i * 5 + 3) & 0x3F);
-    conv2d_run((uint32_t)img8, (uint32_t)out_buf, 8, 8, CONV2D_PAD_SAME, smooth);
+    conv2d_run((uint32_t)(uintptr_t)img8, (uint32_t)(uintptr_t)out_buf, 8, 8, CONV2D_PAD_SAME, smooth);
     conv2d_ref_same(img8, 8, 8, smooth, ref_buf);
     errors += check(out_buf, ref_buf, 64, "Same smooth 8x8");
   }
@@ -305,5 +305,5 @@ int main(int argc, char **argv) {
   putchar('\n');
   if (errors == 0) puts("ALL TESTS PASSED\n");
   else { puts("TESTS FAILED: "); putdec((uint32_t)errors); puts(" error(s)\n"); }
-  return 0;
+  return errors;
 }

--- a/sw/tests/gemm_test/gemm_test.c
+++ b/sw/tests/gemm_test/gemm_test.c
@@ -170,7 +170,7 @@ int main(int argc, char **argv) {
     ref_gemm(a4, b4, ref_buf, 4, 4, 4);
     gemm_load_weights(b4, 4, 4);
     DEV_WRITE(GEMM_CTRL, GEMM_CTRL_SOFT_RESET);
-    gemm_run((uint32_t)a_buf, (uint32_t)c_buf, 4, 4, 4);
+    gemm_run((uint32_t)(uintptr_t)a_buf, (uint32_t)(uintptr_t)c_buf, 4, 4, 4);
 
     status = DEV_READ(GEMM_STATUS, 0);
     if (!(status & GEMM_STATUS_DONE)) { puts("FAIL: DONE not set\n"); errors++; }
@@ -207,7 +207,7 @@ int main(int argc, char **argv) {
 
     pcount_reset();
     pcount_enable(1);
-    gemm_run((uint32_t)a_buf, (uint32_t)c_buf, 8, 8, 8);
+    gemm_run((uint32_t)(uintptr_t)a_buf, (uint32_t)(uintptr_t)c_buf, 8, 8, 8);
     pcount_enable(0);
     uint32_t t4_cycles;
     PCOUNT_READ(mcycle, t4_cycles);
@@ -248,7 +248,7 @@ int main(int argc, char **argv) {
     ref_gemm(a5, id, ref_buf, 4, 4, 4);
     gemm_load_weights(id, 4, 4);
     DEV_WRITE(GEMM_CTRL, GEMM_CTRL_SOFT_RESET);
-    gemm_run((uint32_t)a_buf, (uint32_t)c_buf, 4, 4, 4);
+    gemm_run((uint32_t)(uintptr_t)a_buf, (uint32_t)(uintptr_t)c_buf, 4, 4, 4);
 
     int t5_err = 0;
     for (int i = 0; i < 16; i++) {
@@ -276,7 +276,7 @@ int main(int argc, char **argv) {
 
     gemm_load_weights(z, 4, 4);
     DEV_WRITE(GEMM_CTRL, GEMM_CTRL_SOFT_RESET);
-    gemm_run((uint32_t)a_buf, (uint32_t)c_buf, 4, 4, 4);
+    gemm_run((uint32_t)(uintptr_t)a_buf, (uint32_t)(uintptr_t)c_buf, 4, 4, 4);
 
     int t6_err = 0;
     for (int i = 0; i < 16; i++) {
@@ -306,7 +306,7 @@ int main(int argc, char **argv) {
     ref_gemm(a7, b7, ref_buf, 4, 8, 4);
     gemm_load_weights(b7, 8, 4);
     DEV_WRITE(GEMM_CTRL, GEMM_CTRL_SOFT_RESET);
-    gemm_run((uint32_t)a_buf, (uint32_t)c_buf, 4, 8, 4);
+    gemm_run((uint32_t)(uintptr_t)a_buf, (uint32_t)(uintptr_t)c_buf, 4, 8, 4);
 
     int t7_err = 0;
     for (int i = 0; i < 16; i++) {
@@ -355,7 +355,7 @@ int main(int argc, char **argv) {
 
     gemm_load_weights(kern, 9, 1);
     DEV_WRITE(GEMM_CTRL, GEMM_CTRL_SOFT_RESET);
-    gemm_run((uint32_t)a_buf, (uint32_t)c_buf, 4, 9, 1);
+    gemm_run((uint32_t)(uintptr_t)a_buf, (uint32_t)(uintptr_t)c_buf, 4, 9, 1);
 
     int t8_err = 0;
     for (int i = 0; i < 4; i++) {
@@ -379,5 +379,5 @@ int main(int argc, char **argv) {
     puts("TESTS FAILED: "); putdec((uint32_t)errors); puts(" error(s)\n");
   }
 
-  return 0;
+  return errors;
 }

--- a/sw/tests/relu_test/relu_test.c
+++ b/sw/tests/relu_test/relu_test.c
@@ -75,16 +75,16 @@ int main(int argc, char **argv) {
   // -----------------------------------------------------------------------
   // Phase 2: Configure and launch accelerator
   // -----------------------------------------------------------------------
-  DEV_WRITE(RELU_SRC_ADDR, (uint32_t)src_data);
-  DEV_WRITE(RELU_DST_ADDR, (uint32_t)dst_data);
+  DEV_WRITE(RELU_SRC_ADDR, (uint32_t)(uintptr_t)src_data);
+  DEV_WRITE(RELU_DST_ADDR, (uint32_t)(uintptr_t)dst_data);
   DEV_WRITE(RELU_LEN,      NUM_WORDS);
 
   // Verify config readback
-  if (DEV_READ(RELU_SRC_ADDR, 0) != (uint32_t)src_data) {
+  if (DEV_READ(RELU_SRC_ADDR, 0) != (uint32_t)(uintptr_t)src_data) {
     puts("FAIL: SRC_ADDR readback mismatch\n");
     return 1;
   }
-  if (DEV_READ(RELU_DST_ADDR, 0) != (uint32_t)dst_data) {
+  if (DEV_READ(RELU_DST_ADDR, 0) != (uint32_t)(uintptr_t)dst_data) {
     puts("FAIL: DST_ADDR readback mismatch\n");
     return 1;
   }
@@ -203,5 +203,5 @@ int main(int argc, char **argv) {
     puts(" words incorrect\n");
   }
 
-  return 0;
+  return errors;
 }

--- a/sw/tests/sg_dma_test/sg_dma_test.c
+++ b/sw/tests/sg_dma_test/sg_dma_test.c
@@ -61,7 +61,7 @@ static void putdec(uint32_t v) {
 }
 
 static void run_sgdma(sg_desc_t *desc) {
-  DEV_WRITE(SGDMA_DESC_ADDR, (uint32_t)desc);
+  DEV_WRITE(SGDMA_DESC_ADDR, (uint32_t)(uintptr_t)desc);
   DEV_WRITE(SGDMA_CTRL, SGDMA_CTRL_GO);
 
   // Poll until done
@@ -119,8 +119,8 @@ static void test_single_8word(void) {
     src_buf[i] = 0xA0000000 + i;
     dst_buf[i] = 0;
   }
-  desc1.src_addr       = (uint32_t)src_buf;
-  desc1.dst_addr       = (uint32_t)dst_buf;
+  desc1.src_addr       = (uint32_t)(uintptr_t)src_buf;
+  desc1.dst_addr       = (uint32_t)(uintptr_t)dst_buf;
   desc1.word_len       = 8;
   desc1.ctrl           = 0;
   desc1.next_desc_addr = 0;
@@ -141,8 +141,8 @@ static void test_single_1word(void) {
   src_buf[0] = 0xDEADBEEF;
   dst_buf[0] = 0;
 
-  desc1.src_addr       = (uint32_t)src_buf;
-  desc1.dst_addr       = (uint32_t)dst_buf;
+  desc1.src_addr       = (uint32_t)(uintptr_t)src_buf;
+  desc1.dst_addr       = (uint32_t)(uintptr_t)dst_buf;
   desc1.word_len       = 1;
   desc1.ctrl           = 0;
   desc1.next_desc_addr = 0;
@@ -156,8 +156,8 @@ static void test_single_1word(void) {
 // Test 3: Single descriptor, word_len=0 (should complete immediately)
 // ---------------------------------------------------------------------------
 static void test_zero_len(void) {
-  desc1.src_addr       = (uint32_t)src_buf;
-  desc1.dst_addr       = (uint32_t)dst_buf;
+  desc1.src_addr       = (uint32_t)(uintptr_t)src_buf;
+  desc1.dst_addr       = (uint32_t)(uintptr_t)dst_buf;
   desc1.word_len       = 0;
   desc1.ctrl           = 0;
   desc1.next_desc_addr = 0;
@@ -183,20 +183,20 @@ static void test_chain_3desc(void) {
   }
 
   // Descriptor chain: A → B → C
-  chain_descs[0].src_addr       = (uint32_t)src_a;
-  chain_descs[0].dst_addr       = (uint32_t)dst_a;
+  chain_descs[0].src_addr       = (uint32_t)(uintptr_t)src_a;
+  chain_descs[0].dst_addr       = (uint32_t)(uintptr_t)dst_a;
   chain_descs[0].word_len       = 4;
   chain_descs[0].ctrl           = SGDMA_DESC_CTRL_CHAIN;
-  chain_descs[0].next_desc_addr = (uint32_t)&chain_descs[1];
+  chain_descs[0].next_desc_addr = (uint32_t)(uintptr_t)&chain_descs[1];
 
-  chain_descs[1].src_addr       = (uint32_t)src_b;
-  chain_descs[1].dst_addr       = (uint32_t)dst_b;
+  chain_descs[1].src_addr       = (uint32_t)(uintptr_t)src_b;
+  chain_descs[1].dst_addr       = (uint32_t)(uintptr_t)dst_b;
   chain_descs[1].word_len       = 4;
   chain_descs[1].ctrl           = SGDMA_DESC_CTRL_CHAIN;
-  chain_descs[1].next_desc_addr = (uint32_t)&chain_descs[2];
+  chain_descs[1].next_desc_addr = (uint32_t)(uintptr_t)&chain_descs[2];
 
-  chain_descs[2].src_addr       = (uint32_t)src_c;
-  chain_descs[2].dst_addr       = (uint32_t)dst_c;
+  chain_descs[2].src_addr       = (uint32_t)(uintptr_t)src_c;
+  chain_descs[2].dst_addr       = (uint32_t)(uintptr_t)dst_c;
   chain_descs[2].word_len       = 4;
   chain_descs[2].ctrl           = 0; // Last descriptor, no chain
   chain_descs[2].next_desc_addr = 0;
@@ -245,13 +245,13 @@ static void test_go_while_busy(void) {
     src_buf[i] = 0xBB000000 + i;
     dst_buf[i] = 0;
   }
-  desc1.src_addr       = (uint32_t)src_buf;
-  desc1.dst_addr       = (uint32_t)dst_buf;
+  desc1.src_addr       = (uint32_t)(uintptr_t)src_buf;
+  desc1.dst_addr       = (uint32_t)(uintptr_t)dst_buf;
   desc1.word_len       = 64;
   desc1.ctrl           = 0;
   desc1.next_desc_addr = 0;
 
-  DEV_WRITE(SGDMA_DESC_ADDR, (uint32_t)&desc1);
+  DEV_WRITE(SGDMA_DESC_ADDR, (uint32_t)(uintptr_t)&desc1);
   DEV_WRITE(SGDMA_CTRL, SGDMA_CTRL_GO);
 
   // Immediately try a second GO — should be ignored
@@ -280,8 +280,8 @@ static void test_back_to_back(void) {
     src_buf[i] = 0xCC000000 + i;
     dst_buf[i] = 0;
   }
-  desc1.src_addr       = (uint32_t)src_buf;
-  desc1.dst_addr       = (uint32_t)dst_buf;
+  desc1.src_addr       = (uint32_t)(uintptr_t)src_buf;
+  desc1.dst_addr       = (uint32_t)(uintptr_t)dst_buf;
   desc1.word_len       = 4;
   desc1.ctrl           = 0;
   desc1.next_desc_addr = 0;
@@ -293,8 +293,8 @@ static void test_back_to_back(void) {
     src_buf[i] = 0xDD000000 + i;
     dst_buf[i + 4] = 0;
   }
-  desc1.src_addr       = (uint32_t)src_buf;
-  desc1.dst_addr       = (uint32_t)(dst_buf + 4);
+  desc1.src_addr       = (uint32_t)(uintptr_t)src_buf;
+  desc1.dst_addr       = (uint32_t)(uintptr_t)(dst_buf + 4);
   desc1.word_len       = 4;
   desc1.ctrl           = 0;
   desc1.next_desc_addr = 0;
@@ -321,20 +321,20 @@ static void test_chain_with_zero_len(void) {
   }
 
   // Desc 0: 4-word copy → chain → desc 1 (zero-len) → chain → desc 2 (4-word copy)
-  chain_descs[0].src_addr       = (uint32_t)src_a;
-  chain_descs[0].dst_addr       = (uint32_t)dst_a;
+  chain_descs[0].src_addr       = (uint32_t)(uintptr_t)src_a;
+  chain_descs[0].dst_addr       = (uint32_t)(uintptr_t)dst_a;
   chain_descs[0].word_len       = 4;
   chain_descs[0].ctrl           = SGDMA_DESC_CTRL_CHAIN;
-  chain_descs[0].next_desc_addr = (uint32_t)&chain_descs[1];
+  chain_descs[0].next_desc_addr = (uint32_t)(uintptr_t)&chain_descs[1];
 
   chain_descs[1].src_addr       = 0;
   chain_descs[1].dst_addr       = 0;
   chain_descs[1].word_len       = 0; // Zero length — skip
   chain_descs[1].ctrl           = SGDMA_DESC_CTRL_CHAIN;
-  chain_descs[1].next_desc_addr = (uint32_t)&chain_descs[2];
+  chain_descs[1].next_desc_addr = (uint32_t)(uintptr_t)&chain_descs[2];
 
-  chain_descs[2].src_addr       = (uint32_t)src_c;
-  chain_descs[2].dst_addr       = (uint32_t)dst_c;
+  chain_descs[2].src_addr       = (uint32_t)(uintptr_t)src_c;
+  chain_descs[2].dst_addr       = (uint32_t)(uintptr_t)dst_c;
   chain_descs[2].word_len       = 4;
   chain_descs[2].ctrl           = 0;
   chain_descs[2].next_desc_addr = 0;
@@ -360,8 +360,8 @@ static void test_throughput(void) {
     src_buf[i] = 0xEE000000 + i;
     dst_buf[i] = 0;
   }
-  desc1.src_addr       = (uint32_t)src_buf;
-  desc1.dst_addr       = (uint32_t)dst_buf;
+  desc1.src_addr       = (uint32_t)(uintptr_t)src_buf;
+  desc1.dst_addr       = (uint32_t)(uintptr_t)dst_buf;
   desc1.word_len       = 256;
   desc1.ctrl           = 0;
   desc1.next_desc_addr = 0;
@@ -422,5 +422,5 @@ int main(int argc, char **argv) {
     puts("FAIL\n");
   }
 
-  return 0;
+  return (int)total_errors;
 }

--- a/sw/tests/softmax_test/softmax_test.c
+++ b/sw/tests/softmax_test/softmax_test.c
@@ -85,18 +85,9 @@ static void putdec(uint32_t v) {
   while (pos > 0) putchar(buf[--pos]);
 }
 
-static void putdec_signed(int32_t v) {
-  if (v < 0) {
-    putchar('-');
-    putdec((uint32_t)(-(int64_t)v));
-  } else {
-    putdec((uint32_t)v);
-  }
-}
-
 static void run_softmax(const int8_t *src, uint8_t *dst, int len) {
-  DEV_WRITE(SMAX_SRC_ADDR, (uint32_t)src);
-  DEV_WRITE(SMAX_DST_ADDR, (uint32_t)dst);
+  DEV_WRITE(SMAX_SRC_ADDR, (uint32_t)(uintptr_t)src);
+  DEV_WRITE(SMAX_DST_ADDR, (uint32_t)(uintptr_t)dst);
   DEV_WRITE(SMAX_VEC_LEN, len);
   DEV_WRITE(SMAX_CTRL, SMAX_CTRL_GO);
 
@@ -235,8 +226,8 @@ static void test_all_neg128(void) {
 // Test 6: VEC_LEN=0 (immediate DONE)
 // ---------------------------------------------------------------------------
 static void test_vec_len_zero(void) {
-  DEV_WRITE(SMAX_SRC_ADDR, (uint32_t)input_buf);
-  DEV_WRITE(SMAX_DST_ADDR, (uint32_t)output_buf);
+  DEV_WRITE(SMAX_SRC_ADDR, (uint32_t)(uintptr_t)input_buf);
+  DEV_WRITE(SMAX_DST_ADDR, (uint32_t)(uintptr_t)output_buf);
   DEV_WRITE(SMAX_VEC_LEN, 0);
   DEV_WRITE(SMAX_CTRL, SMAX_CTRL_GO);
 
@@ -372,5 +363,5 @@ int main(int argc, char **argv) {
     puts("FAIL\n");
   }
 
-  return 0;
+  return (int)total_errors;
 }

--- a/sw/tests/vmac_test/vmac_test.c
+++ b/sw/tests/vmac_test/vmac_test.c
@@ -54,26 +54,13 @@ static void putdec_signed(int32_t v) {
   }
 }
 
-// Compute expected dot product with INT32 saturation (using int64_t)
-static int32_t expected_dot(const int8_t *a, const int8_t *b, int len) {
-  int64_t acc = 0;
-  for (int i = 0; i < len; i++) {
-    acc += (int64_t)a[i] * (int64_t)b[i];
-    // Saturate after each group of 4 (matching hardware behavior)
-    if ((i & 3) == 3 || i == len - 1) {
-      if (acc > 2147483647LL) acc = 2147483647LL;
-      if (acc < -2147483648LL) acc = -2147483648LL;
-    }
-  }
-  return (int32_t)acc;
-}
 
 // Run a dot product and return the result
 static int32_t run_vmac(const int8_t *a, const int8_t *b, int32_t *dst,
                         int len, int no_accum_clear) {
-  DEV_WRITE(VMAC_SRC_A_ADDR, (uint32_t)a);
-  DEV_WRITE(VMAC_SRC_B_ADDR, (uint32_t)b);
-  DEV_WRITE(VMAC_DST_ADDR,   (uint32_t)dst);
+  DEV_WRITE(VMAC_SRC_A_ADDR, (uint32_t)(uintptr_t)a);
+  DEV_WRITE(VMAC_SRC_B_ADDR, (uint32_t)(uintptr_t)b);
+  DEV_WRITE(VMAC_DST_ADDR,   (uint32_t)(uintptr_t)dst);
   DEV_WRITE(VMAC_LEN,        len);
 
   uint32_t ctrl = VMAC_CTRL_GO;
@@ -323,5 +310,5 @@ int main(int argc, char **argv) {
     puts("FAIL\n");
   }
 
-  return 0;
+  return (int)total_errors;
 }


### PR DESCRIPTION
## Summary

- **Kronos v0.5.2**: stage5 RV64IMAFD pipeline with FPU — full F/D extension support including FADD, FMUL, FMA, FDIV, FSQRT, FCVT, and FMISC units
- **Synthesis fix**: three RTL changes in Kronos (void function + two variable-bound loops in `kronos_fpu_fadd`) that prevented Vivado from elaborating the FPU; KV260 now generates a bitstream
- **Failure propagation**: `SIM_CTRL_CTRL` bits[31:1] carry the failure count from `main()`; all 9 accelerator tests propagate error counts; Verilator exits non-zero on failures
- **Synth file lists**: `sources.f` and both Vivado TCLs updated from stale stage3 to explicit stage5 RTL list

## Test plan

- [x] `make regression` — 15/15 tests pass
- [x] `make lint` — clean
- [x] `make synth FLOW=fpga-kv260` — bitstream generated (WNS=-1.667 ns at 148 MHz; timing closure is a separate item)