### PR TITLE
feat(fpga): bump Kronos to 0db9693, target 200 MHz on KV260

### DIFF
--- a/hw/fpga/kv260/synth.tcl
+++ b/hw/fpga/kv260/synth.tcl
@@ -29,7 +29,7 @@ set FILELIST    $REPO_ROOT/hw/synth/sources.f
 # ============================================================================
 # Clock frequency — single source of truth
 # ============================================================================
-set CLK_FREQ_MHZ 148
+set CLK_FREQ_MHZ 200
 set CLK_PERIOD   [expr {1000.0 / $CLK_FREQ_MHZ}]
 
 # ============================================================================
@@ -151,6 +151,14 @@ set_property file_type SystemVerilog [get_files $RTL_FILES]
 
 # Constraints (pin assignments only — clock constraint applied below)
 add_files -fileset constrs_1 -norecurse $XDC_FILE
+
+# Kronos timing constraints (multicycle paths for branch comparator)
+set KRONOS_XDC $SRC_DIR/opensoc_ip_kronos_riscv_0/rtl/stage5/kronos_kv260.xdc
+if {[file exists $KRONOS_XDC]} {
+    add_files -fileset constrs_1 -norecurse $KRONOS_XDC
+} else {
+    puts "WARNING: Kronos XDC not found at $KRONOS_XDC — multicycle constraints not applied"
+}
 
 # Clock constraint — derived from CLK_FREQ_MHZ defined at top of this script
 set clk_xdc [file join $PROJ_DIR clk.xdc]


### PR DESCRIPTION
Closes #41

## Summary

- Bump Kronos submodule to `0db9693` (muldiv redirect stall fix: gate `muldiv_req`/`muldiv_stall` on `~ex_redirect & ~mem_redirect`)
- Set `CLK_FREQ_MHZ 200` in `hw/fpga/kv260/synth.tcl`; PS PL0 clock and period derive from it automatically
- Import Kronos multicycle path XDC (`rtl/stage5/kronos_kv260.xdc`) — 2-cycle relaxation for the 64-bit branch comparator

## Regression (Kronos 0db9693)

11/15 tests pass. 4 pre-existing failures (relu, sg-dma, softmax, conv2d-relu-softmax-stream) are unchanged from `efcc59c` — no new regressions.

## Synthesis Result (KV260, XCK26-2LV)

| Metric | Value |
|--------|-------|
| Target | 200 MHz (5.000 ns) |
| WNS (post-route + phys_opt) | -0.018 ns |
| Max achievable | 199.3 MHz |
| Hold | met (WHS = +0.010 ns) |
| Bitstream | generated |

Worst path: `mem_wb_q_reg[lsu_rdata]` → branch predictor update (CARRY8 chain) → `pc_q_reg` — 18 logic levels, 4.999 ns.