### PR TITLE
docs: Mermaid diagrams and development-loop process

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,35 @@ When executing implementation plans with subagent-driven development, independen
 
 **Rule:** if two tasks edit different files and neither depends on the other's output, they can run in parallel. Dispatch them as a single multi-agent call using `superpowers:dispatching-parallel-agents`.
 
+## Subagent Models
+
+The main conversation (brainstorming, plan writing, orchestration) runs on the session model — never downgrade it.
+
+When dispatching subagents, always set the `model` parameter on the Agent call:
+
+- Implementation / execution subagents (task implementers, test writers, fix-up agents): `model: "sonnet"`.
+- Exploration and search subagents (Explore, codebase lookups): `model: "sonnet"`.
+- Code-review, spec-review, and plan-review subagents: omit the `model` parameter so they inherit the main-session model.
+
+Do not set `CLAUDE_CODE_SUBAGENT_MODEL` in settings — it would override the per-dispatch routing above.
+
+## Development Loop
+
+Feature and accelerator implementation follows this loop:
+
+1. **Brainstorm → spec → plan** (superpowers:brainstorming, spec review against the existing architecture docs, superpowers:writing-plans at full-runnable-code depth). Stop for user review after the spec and after the plan.
+2. **Execute with superpowers:subagent-driven-development**: fresh implementer subagent per task (sonnet, per Subagent Models above), task briefs extracted to files, TDD with *observed* fail-then-pass evidence quoted in a per-task report file.
+3. **Independent review after every task** (main-session model): spec compliance AND code quality, with the reviewer given the brief, the report, and the full diff as files. Findings enter scoped fix rounds (fix → scoped re-review), never silent discards; minors go to the ledger.
+4. **Ledger everything** in `.superpowers/sdd/<plan>/progress.md`: completions, fix rounds, deferred minors, carry-overs between tasks, and user decisions. The ledger survives context loss; trust it and `git log` over recollection.
+5. **Synthesis gates**: re-run `make synth` after RTL-touching tasks when the change could move timing or resources. On a timing miss: analyze failing-path classes first, try zero-RTL directive escalation before RTL changes, and make every RTL timing fix behavior-identical and sim-gated.
+6. **Final whole-branch review** (most capable model) with the ledger's deferred-minors list for merge triage; ONE fix wave + one scoped re-review.
+7. **Board last**: `make lint` and the full Verilator regression must be green before any KV260 run, and every board scenario must already have an equivalent simulation twin at the same scale (same data sizes, descriptor counts, and iteration/loop counts — bugs like boundary-crossing effects only appear at real scale). Predict register/counter values before each command; on mismatch stop and decode, never guess.
+8. **Update the checked-in documentation as part of closing the work** — a change is not done until the docs that describe it are true again: `README.md`, the module doc under `docs/<module>/`, and the Architecture / Repository Structure sections of this file. This is a closing step, not an optional follow-up.
+
+## Diagrams
+
+Use Mermaid fenced code blocks (` ```mermaid `) for all block diagrams, FSMs, and dataflow diagrams in the markdown docs — GitHub renders them natively, no build step. Bit-field encodings and register layouts are markdown tables. Do not use ASCII art diagrams.
+
 ## SW Tests
 
 When creating a new SW test under `sw/tests/`, always update `sw/tests/tests.mk`:

--- a/docs/conv1d/conv1d.md
+++ b/docs/conv1d/conv1d.md
@@ -39,86 +39,57 @@ conv1d.sv (control registers + DMA FSM)
 
 A parameterized shift register with `DEPTH = KERNEL_SIZE` and `WIDTH = 8` (INT8). One new sample is loaded per cycle when the DMA returns valid data. The register presents all `DEPTH` entries simultaneously to the PE.
 
-```
-Input sample (INT8)
-       │
-       ▼
-  ┌────────┐  ┌────────┐  ┌────────┐       ┌────────┐
-  │ reg[0] │→ │ reg[1] │→ │ reg[2] │→ ... →│reg[N-1]│
-  └────────┘  └────────┘  └────────┘       └────────┘
-       │            │           │                │
-    w[0]         w[1]        w[2]            w[N-1]   (kernel weights)
-       │            │           │                │
-       └────────────┴───────────┴────────────────┘
-                              │
-                         conv1d_pe
+```mermaid
+flowchart LR
+    in["Input sample (INT8)"] --> r0["reg[0]"] --> r1["reg[1]"] --> r2["reg[2]"] --> rdots["…"] --> rn["reg[N−1]"]
+    r0 -- "× w[0]" --> pe["conv1d_pe"]
+    r1 -- "× w[1]" --> pe
+    r2 -- "× w[2]" --> pe
+    rn -- "× w[N−1]" --> pe
 ```
 
 ### conv1d_pe.sv
 
 `KERNEL_SIZE` parallel signed multipliers, each computing `reg[k] * w[k]` (INT8 × INT8 → INT16). The products are summed into a single INT32 accumulator. One valid output is produced per cycle when `valid_i` is asserted (i.e., after the shift register has been filled for the first time and on every subsequent shift).
 
-```
-reg[0]×w[0] ──┐
-reg[1]×w[1] ──┤
-reg[2]×w[2] ──┼──► partial_sum (INT32) ──► result_o (INT32)
-    ⋮         │
-reg[N-1]×w[N-1]┘
+```mermaid
+flowchart LR
+    m0["reg[0] × w[0]"] --> sum["partial_sum (INT32)"]
+    m1["reg[1] × w[1]"] --> sum
+    m2["reg[2] × w[2]"] --> sum
+    mdots["⋮"] --> sum
+    mn["reg[N−1] × w[N−1]"] --> sum
+    sum --> result_o["result_o (INT32)"]
 ```
 
 No saturation is applied at the PE level — INT8×INT8 products fit in INT16, and the sum of 16 such products fits within INT32 range.
 
 ## FSM
 
-```
-              GO
-IDLE ─────────────────► RD_REQ
-                           │
-                         gnt
-                           │
-                           ▼
-                        RD_WAIT ◄──────────────────────────┐
-                           │                               │
-                         rvalid                            │
-                           │                               │
-                    shift sample in                        │
-                    compute PE output                      │
-                           │                               │
-                   kernel full?                            │
-                    ┌──yes─┴──no──┐                        │
-                    ▼             ▼                        │
-                 WR_REQ        RD_REQ ─► (next sample) ───┘
-                    │
-                  gnt
-                    │
-                    ▼
-                 WR_WAIT
-                    │
-                  rvalid
-                    │
-          samples remaining?
-              ┌──yes──┴──no──┐
-              ▼              ▼
-           RD_REQ           IDLE (DONE)
+```mermaid
+stateDiagram-v2
+    [*] --> IDLE
+    IDLE --> RD_REQ : GO
+    RD_REQ --> RD_WAIT : gnt
+    RD_WAIT : RD_WAIT — on rvalid, shift sample in and compute PE output
+    RD_WAIT --> RD_REQ : rvalid & kernel not full (next sample)
+    RD_WAIT --> WR_REQ : rvalid & kernel full
+    WR_REQ --> WR_WAIT : gnt
+    WR_WAIT --> RD_REQ : rvalid & samples remaining
+    WR_WAIT --> IDLE : rvalid & no samples remaining (DONE)
 ```
 
 **Stream mode** (`CTRL[2]=1`): the `WR_REQ`/`WR_WAIT` states are bypassed. After each PE result is captured the FSM enters `STREAM_OUT`, drives the AXI-Stream output, and waits for `m_axis_tready` before advancing to the next read or returning to IDLE.
 
-```
-              GO (stream mode)
-IDLE ──────────────────► RD_REQ
-                            │
-                          gnt
-                            ▼
-                         RD_WAIT
-                            │ rvalid + kernel full
-                            ▼
-                        STREAM_OUT  ◄── holds until m_axis_tready
-                            │
-                  last element?
-                    ┌──yes──┴──no──┐
-                    ▼              ▼
-                   IDLE          RD_REQ
+```mermaid
+stateDiagram-v2
+    [*] --> IDLE
+    IDLE --> RD_REQ : GO (stream mode)
+    RD_REQ --> RD_WAIT : gnt
+    RD_WAIT --> STREAM_OUT : rvalid & kernel full
+    STREAM_OUT : STREAM_OUT — holds until m_axis_tready
+    STREAM_OUT --> RD_REQ : not last element
+    STREAM_OUT --> IDLE : last element
 ```
 
 **Causal zero-pad mode (same):** before the first real read, `KERNEL_SIZE-1` virtual-zero samples are pre-counted in the fill counter, so the first output is produced immediately after the first real read. The pre-fill does not generate DMA reads. The output formula is:

--- a/docs/conv2d/conv2d.md
+++ b/docs/conv2d/conv2d.md
@@ -41,10 +41,11 @@ conv2d.sv (control registers + DMA FSM)
 
 Three flip-flop arrays of depth `MAX_WIDTH` (default 64), each holding one row of INT8 pixels. The three rows are indexed modulo 3 — the accelerator rotates which physical slot corresponds to the "oldest", "middle", and "newest" row as it advances through the image. Written one pixel per cycle; read combinationally as a full `[3][MAX_WIDTH]` array. Cleared synchronously on `clr_i` (SOFT_RESET).
 
-```
-Row slot 0  [ p[0]  p[1]  p[2]  ...  p[63] ]
-Row slot 1  [ p[0]  p[1]  p[2]  ...  p[63] ]   ──► pixels_o [3][64]
-Row slot 2  [ p[0]  p[1]  p[2]  ...  p[63] ]
+```mermaid
+flowchart LR
+    s0["Row slot 0 — p[0] … p[63]"] --> out["pixels_o [3][64]"]
+    s1["Row slot 1 — p[0] … p[63]"] --> out
+    s2["Row slot 2 — p[0] … p[63]"] --> out
 ```
 
 The FSM selects which physical slot is oldest/middle/newest via modular arithmetic on `cur_row_q`:
@@ -59,16 +60,18 @@ newest_slot =  cur_row_q      % 3
 
 Nine parallel signed INT8×INT8 multipliers, producing nine INT16 products. The products are sign-extended to INT32 and summed. The output is purely combinational; `conv2d.sv` registers the result before issuing the DMA write.
 
-```
-window[0][0]×w[0] ──┐
-window[0][1]×w[1] ──┤
-window[0][2]×w[2] ──┤
-window[1][0]×w[3] ──┤
-window[1][1]×w[4] ──┼──► result_o (INT32)
-window[1][2]×w[5] ──┤
-window[2][0]×w[6] ──┤
-window[2][1]×w[7] ──┤
-window[2][2]×w[8] ──┘
+```mermaid
+flowchart LR
+    m0["window[0][0] × w[0]"] --> sum["Σ (sign-extend to INT32)"]
+    m1["window[0][1] × w[1]"] --> sum
+    m2["window[0][2] × w[2]"] --> sum
+    m3["window[1][0] × w[3]"] --> sum
+    m4["window[1][1] × w[4]"] --> sum
+    m5["window[1][2] × w[5]"] --> sum
+    m6["window[2][0] × w[6]"] --> sum
+    m7["window[2][1] × w[7]"] --> sum
+    m8["window[2][2] × w[8]"] --> sum
+    sum --> result_o["result_o (INT32)"]
 ```
 
 No overflow is possible: the worst case is `9 × 127 × 127 = 145,161`, which is well within INT32 range.
@@ -91,45 +94,21 @@ The accelerator uses a 7-state FSM. The image is processed in two phases:
 
 **SLIDE phase** — reads one pixel per position, computes the PE output when the column window is valid (`cur_col_q ≥ lag`), and writes the result. Virtual pixels (zero-padded borders in same mode) skip the DMA read.
 
-```
-                  GO
-IDLE ──────────────────► FILL_RD_REQ
-                              │
-                            gnt
-                              │
-                              ▼
-                         FILL_RD_WAIT ◄─────────────────┐
-                              │                          │
-                           rvalid                        │ more fill cols/rows
-                              │                          │
-                     fill complete? ─────────────────────┘
-                              │ yes
-                              ▼
-                         SLIDE_RD_REQ ◄─────────────────────────────────┐
-                              │                                          │
-                     virtual? │ no: assert dma_req                      │
-                              │    wait for gnt                         │
-                              ▼                                          │
-                         SLIDE_RD_WAIT                                   │
-                              │                                          │
-                    virtual or rvalid                                    │
-                              │                                          │
-                   write lb; should_output?                              │
-                       ┌─yes──┴──no──┐                                  │
-                       ▼             └──── advance col/row ─────────────┘
-                  SLIDE_WR_REQ
-                       │
-                     gnt
-                       │
-                       ▼
-                  SLIDE_WR_WAIT
-                       │
-                     rvalid
-                       │
-              last output? ─────────────────── advance col/row ─────────┘
-                       │ yes
-                       ▼
-                      IDLE (DONE)
+```mermaid
+stateDiagram-v2
+    [*] --> IDLE
+    IDLE --> FILL_RD_REQ : GO
+    FILL_RD_REQ --> FILL_RD_WAIT : gnt
+    FILL_RD_WAIT --> FILL_RD_REQ : rvalid & more fill cols/rows
+    FILL_RD_WAIT --> SLIDE_RD_REQ : rvalid & fill complete
+    SLIDE_RD_REQ : SLIDE_RD_REQ — assert dma_req unless virtual pixel
+    SLIDE_RD_REQ --> SLIDE_RD_WAIT : gnt (or virtual)
+    SLIDE_RD_WAIT : SLIDE_RD_WAIT — on virtual or rvalid, write line buffer
+    SLIDE_RD_WAIT --> SLIDE_WR_REQ : should_output
+    SLIDE_RD_WAIT --> SLIDE_RD_REQ : ~should_output (advance col/row)
+    SLIDE_WR_REQ --> SLIDE_WR_WAIT : gnt
+    SLIDE_WR_WAIT --> SLIDE_RD_REQ : rvalid & not last output (advance col/row)
+    SLIDE_WR_WAIT --> IDLE : rvalid & last output (DONE)
 ```
 
 **`should_output`** is asserted when `cur_col_q ≥ lag_q` — meaning the full left side of the 3-column window falls within the image (or virtual zero region).
@@ -175,11 +154,11 @@ Base address: `0x400A0000`.
 
 **Kernel weight layout** (row-major, top-left to bottom-right):
 
-```
-W[0]  W[1]  W[2]
-W[3]  W[4]  W[5]
-W[6]  W[7]  W[8]
-```
+| | left | center | right |
+|---|---|---|---|
+| **top** | W[0] | W[1] | W[2] |
+| **middle** | W[3] | W[4] | W[5] |
+| **bottom** | W[6] | W[7] | W[8] |
 
 ### CTRL Register (0x00)
 
@@ -241,10 +220,11 @@ One INT32 beat is emitted per output pixel. The FSM holds in `STREAM_OUT` until 
 
 Conv2D's stream output is OR-muxed with Conv1D's into ReLU's stream input, then ReLU's stream output feeds Softmax's stream input:
 
-```
-Conv1D m_axis ─┐
-               ├─(OR mux)─► ReLU s_axis ──► ReLU m_axis ──► Softmax s_axis
-Conv2D m_axis ─┘
+```mermaid
+flowchart LR
+    c1["Conv1D m_axis"] --> mux["OR mux"]
+    c2["Conv2D m_axis"] --> mux
+    mux --> relu_in["ReLU s_axis"] --> relu_out["ReLU m_axis"] --> smax["Softmax s_axis"]
 ```
 
 Only one config runs at a time; the inactive upstream holds `tvalid = 0`. The mux selects Conv1D's data when Conv1D is active, Conv2D's otherwise.

--- a/docs/gemm/gemm.md
+++ b/docs/gemm/gemm.md
@@ -40,20 +40,13 @@ gemm.sv (control registers + DMA FSM)
 
 Each PE holds one INT8 weight register (`w_q`) and one INT32 accumulator (`acc_q`). On a MAC enable pulse (`en_i`), the PE computes `acc_q += a_in_i * w_q`. The weight is loaded independently via `set_w_i` / `w_i`; the accumulator is cleared synchronously via `clr_i`.
 
-```
-     set_w_i, w_i
-          │
-    ┌─────▼─────┐
-    │   w_q     │  (INT8 weight register)
-    └─────┬─────┘
-          │
-a_in_i ──►│  MAC (en_i)
-          │
-    ┌─────▼─────┐
-    │   acc_q   │  (INT32 accumulator)
-    └─────┬─────┘
-          │
-       acc_o
+```mermaid
+flowchart TB
+    setw["set_w_i / w_i"] --> wq["w_q<br>(INT8 weight register)"]
+    wq --> mac["MAC (en_i)<br>acc_q += a_in_i × w_q"]
+    a_in_i --> mac
+    mac --> accq["acc_q<br>(INT32 accumulator)"]
+    accq --> acc_o
 ```
 
 A pass-through register (`a_out_q`) propagates `a_in_i` eastward to the next PE in the same row, though the current implementation broadcasts each `skew_out[k]` to all N columns in row k rather than using east-flow propagation.
@@ -62,15 +55,13 @@ A pass-through register (`a_out_q`) propagates `a_in_i` eastward to the next PE 
 
 A chain of 7 explicit flip-flop stages introduces a per-row delay: row 0 sees the input directly, row 1 sees it one cycle later, …, row 7 sees it seven cycles later. This ensures that when the MAC enable fires at the end of the 8-cycle SKEW_FEED phase, each row k has the correct A element (`A[m][k]`) at its input.
 
-```
-cycle:    0     1     2     3     4     5     6     7 (en)
-         ─────────────────────────────────────────────────
-row 0    a[7]  a[6]  a[5]  a[4]  a[3]  a[2]  a[1]  a[0] ✓
-row 1     0    a[7]  a[6]  a[5]  a[4]  a[3]  a[2]  a[1] ✓
-row 2     0     0    a[7]  a[6]  a[5]  a[4]  a[3]  a[2] ✓
-  ⋮
-row 7     0     0     0     0     0     0     0    a[7] ✓
-```
+| | cycle 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 (en) |
+|---|---|---|---|---|---|---|---|---|
+| row 0 | a[7] | a[6] | a[5] | a[4] | a[3] | a[2] | a[1] | a[0] ✓ |
+| row 1 | 0 | a[7] | a[6] | a[5] | a[4] | a[3] | a[2] | a[1] ✓ |
+| row 2 | 0 | 0 | a[7] | a[6] | a[5] | a[4] | a[3] | a[2] ✓ |
+| ⋮ | | | | | | | | |
+| row 7 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | a[7] ✓ |
 
 The reversed-order feed (`a[7-k]` at cycle k, where unused indices are zero-extended) is what aligns each row's data with the enable pulse.
 
@@ -96,58 +87,26 @@ The 8-input sum is implemented as a chain: `s0 = acc[0]+acc[1]`, `s1 = s0+acc[2]
 
 The accelerator uses a 7-state FSM. The outer loop iterates over M output rows; for each row it clears the accumulators, reads K elements of A via DMA, runs the 8-cycle skew-feed, then writes N output elements via DMA.
 
-```
-              GO
-IDLE ─────────────────► COMPUTE_CLR
-                              │
-                         assert sa_clr
-                         reset k, n
-                              │
-                              ▼
-                           RD_REQ ◄────────────────────────┐
-                              │                            │
-                        assert dma_req                     │
-                              │                            │
-                            gnt                            │
-                              │                            │
-                              ▼                            │
-                           RD_WAIT                         │
-                              │                            │
-                           rvalid                          │
-                              │                            │
-                    store a_row_buf[k]                     │
-                              │                            │
-                     k == K-1? ─── no: k++ ───────────────┘
-                              │ yes: k=0
-                              ▼
-                          SKEW_FEED ◄──────────────────────┐
-                              │                            │
-                  feed a_row_buf[7-k] to skew              │
-                     advance k                             │
-                              │                            │
-                     k == 7? ─── no ──────────────────────┘
-                     (en fires)
-                              │ yes: k=0
-                              ▼
-                           WR_REQ ◄────────────────────────┐
-                              │                            │
-                        assert dma_req                     │
-                        write drain[n]                     │
-                              │                            │
-                            gnt                            │
-                              │                            │
-                              ▼                            │
-                           WR_WAIT                         │
-                              │                            │
-                           rvalid                          │
-                              │                            │
-                     n == N-1? ─── no: n++ ───────────────┘
-                              │ yes: n=0
-                              │
-                     m == M-1? ─── no: m++, ──► COMPUTE_CLR
-                              │ yes
-                              ▼
-                          IDLE (DONE)
+```mermaid
+stateDiagram-v2
+    [*] --> IDLE
+    COMPUTE_CLR : COMPUTE_CLR — assert sa_clr, reset k and n
+    RD_REQ : RD_REQ — assert dma_req
+    RD_WAIT : RD_WAIT — on rvalid, store a_row_buf[k]
+    SKEW_FEED : SKEW_FEED — feed a_row_buf[7−k] to skew, advance k
+    WR_REQ : WR_REQ — assert dma_req, write drain[n]
+    WR_WAIT : WR_WAIT — wait rvalid
+    IDLE --> COMPUTE_CLR : GO
+    COMPUTE_CLR --> RD_REQ
+    RD_REQ --> RD_WAIT : gnt
+    RD_WAIT --> RD_REQ : rvalid & k < K−1 (k++)
+    RD_WAIT --> SKEW_FEED : rvalid & k == K−1 (k=0)
+    SKEW_FEED --> SKEW_FEED : k < 7
+    SKEW_FEED --> WR_REQ : k == 7 (en fires, k=0)
+    WR_REQ --> WR_WAIT : gnt
+    WR_WAIT --> WR_REQ : rvalid & n < N−1 (n++)
+    WR_WAIT --> COMPUTE_CLR : rvalid & n == N−1 & m < M−1 (n=0, m++)
+    WR_WAIT --> IDLE : rvalid & n == N−1 & m == M−1 (DONE)
 ```
 
 **Weight preload:** before asserting GO, software writes each B[k][n] element by setting `WEIGHT_ADDR = (k << 3) | n` then writing `WEIGHT_DATA`. This fires `set_w_i` on the matching PE immediately. Weights persist across GO pulses; only a SOFT_RESET or a new weight write changes them.

--- a/docs/pio/pio.md
+++ b/docs/pio/pio.md
@@ -55,18 +55,19 @@ The PIO block occupies the GPIO slot in the AXI4 crossbar:
 
 ### Pin I/O
 
-```
-                    ┌──────────────────┐
-    gpio_i[31:0] ──►│  2-FF Sync       │──► synced_pins ──► SM IN sources
-                    └──────────────────┘                ──► GPIO_IN register
-
-   SM0 out ──┐
-   SM1 out ──┤     ┌──────────────────┐
-   SM2 out ──┼────►│  Pin Mux (reg'd) │──► gpio_o[31:0]
-   SM3 out ──┘     │  SM3>SM2>SM1>SM0 │──► gpio_oe[31:0]
-   GPIO_OUT ──────►│  >GPIO compat    │
-   GPIO_DIR ──────►│                  │
-                   └──────────────────┘
+```mermaid
+flowchart LR
+    gpio_i["gpio_i [31:0]"] --> sync["2-FF Sync"] --> synced["synced_pins"]
+    synced --> smin["SM IN sources"]
+    synced --> gin["GPIO_IN register"]
+    sm0["SM0 out"] --> mux["Pin Mux (registered)<br>SM3 > SM2 > SM1 > SM0<br>> GPIO compat"]
+    sm1["SM1 out"] --> mux
+    sm2["SM2 out"] --> mux
+    sm3["SM3 out"] --> mux
+    gout["GPIO_OUT"] --> mux
+    gdir["GPIO_DIR"] --> mux
+    mux --> gpio_o["gpio_o [31:0]"]
+    mux --> gpio_oe["gpio_oe [31:0]"]
 ```
 
 **Pin mux priority:** SM3 > SM2 > SM1 > SM0 > GPIO compat registers. A pin belongs to an SM's driven set if it falls within that SM's configured OUT, SET, or SIDE-SET pin range and the SM is enabled. Pins not claimed by any enabled SM are controlled by GPIO compat registers.
@@ -153,12 +154,9 @@ Threshold value of 0 means 32 bits.
 
 All instructions are 16 bits wide:
 
-```
-┌───────────┬───────────────┬─────────────────────┐
-│  15:13    │    12:8       │       7:0           │
-│  Opcode   │ Delay/Sideset │ Instruction operands│
-└───────────┴───────────────┴─────────────────────┘
-```
+| 15:13 | 12:8 | 7:0 |
+|---|---|---|
+| Opcode | Delay/Sideset | Instruction operands |
 
 ### Delay and Side-set Field (bits 12:8)
 
@@ -179,12 +177,9 @@ Side-set values are applied to consecutive pins starting from `SIDESET_BASE`.
 
 Conditional branch.
 
-```
-┌─────┬───────────┬─────────┬───────────┐
-│ 000 │ delay/ss  │  cond   │  address  │
-│15:13│   12:8    │  7:5    │   4:0     │
-└─────┴───────────┴─────────┴───────────┘
-```
+| 15:13 | 12:8 | 7:5 | 4:0 |
+|---|---|---|---|
+| 000 | delay/ss | cond | address |
 
 | Condition (7:5) | Mnemonic | Description |
 |-----------------|----------|-------------|
@@ -203,12 +198,9 @@ Target address in bits 4:0.
 
 Stall until a condition is met.
 
-```
-┌─────┬───────────┬────┬────────┬───────────┐
-│ 001 │ delay/ss  │ pol│ source │   index   │
-│15:13│   12:8    │ 7  │  6:5   │   4:0     │
-└─────┴───────────┴────┴────────┴───────────┘
-```
+| 15:13 | 12:8 | 7 | 6:5 | 4:0 |
+|---|---|---|---|---|
+| 001 | delay/ss | pol | source | index |
 
 | Source (6:5) | Description |
 |-------------|-------------|
@@ -224,12 +216,9 @@ For `WAIT IRQ`, once the condition is met, the flag is automatically cleared.
 
 Shift bits into ISR from a source.
 
-```
-┌─────┬───────────┬──────────┬───────────┐
-│ 010 │ delay/ss  │  source  │ bit_count │
-│15:13│   12:8    │   7:5    │   4:0     │
-└─────┴───────────┴──────────┴───────────┘
-```
+| 15:13 | 12:8 | 7:5 | 4:0 |
+|---|---|---|---|
+| 010 | delay/ss | source | bit_count |
 
 | Source (7:5) | Description |
 |-------------|-------------|
@@ -246,12 +235,9 @@ Bit count in bits 4:0 (value 0 means 32 bits). Bits are shifted into ISR accordi
 
 Shift bits from OSR to a destination.
 
-```
-┌─────┬───────────┬─────────────┬───────────┐
-│ 011 │ delay/ss  │ destination │ bit_count │
-│15:13│   12:8    │    7:5      │   4:0     │
-└─────┴───────────┴─────────────┴───────────┘
-```
+| 15:13 | 12:8 | 7:5 | 4:0 |
+|---|---|---|---|
+| 011 | delay/ss | destination | bit_count |
 
 | Destination (7:5) | Description |
 |-------------------|-------------|
@@ -270,12 +256,9 @@ Bit count in bits 4:0 (value 0 means 32 bits). Bits are shifted out of OSR accor
 
 Transfer data between shift registers and FIFOs.
 
-```
-┌─────┬───────────┬────┬────┬────┬─────────┐
-│ 100 │ delay/ss  │ P  │ IF │ BLK│  (rsvd) │
-│15:13│   12:8    │ 7  │ 6  │  5 │  4:0    │
-└─────┴───────────┴────┴────┴────┴─────────┘
-```
+| 15:13 | 12:8 | 7 | 6 | 5 | 4:0 |
+|---|---|---|---|---|---|
+| 100 | delay/ss | P | IF | BLK | (rsvd) |
 
 | Bit | Name | Description |
 |-----|------|-------------|
@@ -290,12 +273,9 @@ Transfer data between shift registers and FIFOs.
 
 Copy data between registers with optional transformation.
 
-```
-┌─────┬───────────┬─────────────┬──────┬──────────┐
-│ 101 │ delay/ss  │ destination │  op  │  source  │
-│15:13│   12:8    │    7:5      │ 4:3  │   2:0    │
-└─────┴───────────┴─────────────┴──────┴──────────┘
-```
+| 15:13 | 12:8 | 7:5 | 4:3 | 2:0 |
+|---|---|---|---|---|
+| 101 | delay/ss | destination | op | source |
 
 **Sources (2:0):**
 
@@ -333,12 +313,9 @@ Copy data between registers with optional transformation.
 
 Set, clear, or wait on IRQ flags.
 
-```
-┌─────┬───────────┬─────┬────┬─────┬───────────┐
-│ 110 │ delay/ss  │(rsvd)│WAIT│ CLR │   index  │
-│15:13│   12:8    │  7  │  6 │  5  │   4:0     │
-└─────┴───────────┴─────┴────┴─────┴───────────┘
-```
+| 15:13 | 12:8 | 7 | 6 | 5 | 4:0 |
+|---|---|---|---|---|---|
+| 110 | delay/ss | (rsvd) | WAIT | CLR | index |
 
 | Bit | Name | Description |
 |-----|------|-------------|
@@ -352,12 +329,9 @@ Set, clear, or wait on IRQ flags.
 
 Write a 5-bit immediate value to a destination.
 
-```
-┌─────┬───────────┬─────────────┬───────────┐
-│ 111 │ delay/ss  │ destination │   data    │
-│15:13│   12:8    │    7:5      │   4:0     │
-└─────┴───────────┴─────────────┴───────────┘
-```
+| 15:13 | 12:8 | 7:5 | 4:0 |
+|---|---|---|---|
+| 111 | delay/ss | destination | data |
 
 | Destination (7:5) | Description |
 |-------------------|-------------|

--- a/docs/sg_dma/sg_dma.md
+++ b/docs/sg_dma/sg_dma.md
@@ -50,15 +50,12 @@ Each descriptor is a 5-word (20-byte) struct stored in DRAM at a word-aligned ad
 
 ### Descriptor Chaining
 
-```
-Descriptor 0          Descriptor 1          Descriptor 2
-┌────────────┐        ┌────────────┐        ┌────────────┐
-│ src_addr   │        │ src_addr   │        │ src_addr   │
-│ dst_addr   │        │ dst_addr   │        │ dst_addr   │
-│ word_len   │        │ word_len   │        │ word_len   │
-│ ctrl=CHAIN │──next─►│ ctrl=CHAIN │──next─►│ ctrl=0     │
-│ next_desc  │        │ next_desc  │        │ next_desc  │
-└────────────┘        └────────────┘        └────────────┘
+```mermaid
+flowchart LR
+    d0["Descriptor 0<br>src_addr<br>dst_addr<br>word_len<br>ctrl = CHAIN<br>next_desc"]
+    d1["Descriptor 1<br>src_addr<br>dst_addr<br>word_len<br>ctrl = CHAIN<br>next_desc"]
+    d2["Descriptor 2<br>src_addr<br>dst_addr<br>word_len<br>ctrl = 0<br>next_desc"]
+    d0 -- next --> d1 -- next --> d2
 ```
 
 ### Zero-Length Descriptors
@@ -67,24 +64,19 @@ If `word_len` is 0, the DMA engine skips the copy phase entirely: it increments 
 
 ## FSM
 
-```
-                 GO
-IDLE ──────── FETCH_REQ ──► FETCH_WAIT ──► (repeat 5x for descriptor fields)
-                                │
-                                ▼
-                          COPY_RD_REQ ──► COPY_RD_WAIT ──► COPY_WR_REQ ──► COPY_WR_WAIT
-                                                                              │
-                                              ┌───────────────────────────────┘
-                                              ▼
-                                         remaining > 1? ──yes──► COPY_RD_REQ (loop)
-                                              │
-                                              no
-                                              ▼
-                                         CHAIN? ──yes──► FETCH_REQ (next descriptor)
-                                              │
-                                              no
-                                              ▼
-                                            IDLE (done)
+```mermaid
+stateDiagram-v2
+    [*] --> IDLE
+    IDLE --> FETCH_REQ : GO
+    FETCH_REQ --> FETCH_WAIT
+    FETCH_WAIT --> FETCH_REQ : more descriptor fields (5 reads total)
+    FETCH_WAIT --> COPY_RD_REQ : descriptor loaded
+    COPY_RD_REQ --> COPY_RD_WAIT
+    COPY_RD_WAIT --> COPY_WR_REQ
+    COPY_WR_REQ --> COPY_WR_WAIT
+    COPY_WR_WAIT --> COPY_RD_REQ : remaining > 1
+    COPY_WR_WAIT --> FETCH_REQ : remaining ≤ 1 & CHAIN (next descriptor)
+    COPY_WR_WAIT --> IDLE : remaining ≤ 1 & ~CHAIN (done)
 ```
 
 7 states, single DMA master port shared between descriptor fetch and data copy.

--- a/docs/softmax/softmax.md
+++ b/docs/softmax/softmax.md
@@ -105,24 +105,23 @@ The LUT-based approximation matches the mathematical softmax within ±2 LSB for 
 
 ## FSM
 
-```
-         GO (LEN>0)
-IDLE ──────── P1_RD_REQ ──► P1_RD_WAIT ──► (loop for all words)
-                                │
-                                ▼
-                          P2_COMPUTE ──► (1 element/cycle, N cycles)
-                                │
-                                ▼
-                          P2_RECIP ──► (17 cycles, sequential divider)
-                                │
-                                ▼
-                          P3_NORM ──► (pack 4 bytes)
-                                │
-                                ▼
-                          P3_WR_REQ ──► P3_WR_WAIT ──► (loop for all words)
-                                                           │
-                                                           ▼
-                                                     DONE_STATE ──► IDLE
+```mermaid
+stateDiagram-v2
+    [*] --> IDLE
+    IDLE --> P1_RD_REQ : GO (LEN > 0)
+    P1_RD_REQ --> P1_RD_WAIT
+    P1_RD_WAIT --> P1_RD_REQ : more words
+    P1_RD_WAIT --> P2_COMPUTE : last word
+    P2_COMPUTE : P2_COMPUTE — 1 element/cycle, N cycles
+    P2_COMPUTE --> P2_RECIP
+    P2_RECIP : P2_RECIP — 17 cycles, sequential divider
+    P2_RECIP --> P3_NORM
+    P3_NORM : P3_NORM — pack 4 bytes
+    P3_NORM --> P3_WR_REQ
+    P3_WR_REQ --> P3_WR_WAIT
+    P3_WR_WAIT --> P3_NORM : more words
+    P3_WR_WAIT --> DONE_STATE : last word
+    DONE_STATE --> IDLE
 ```
 
 9 states. Pass 2 and the reciprocal divider are fully internal (no DMA transactions).

--- a/docs/vec_mac/vec_mac.md
+++ b/docs/vec_mac/vec_mac.md
@@ -36,12 +36,16 @@ vec_mac.sv (control + DMA FSM)
 
 ### Data Path
 
-```
-a_data_i[31:0]  ──┬── a[7:0]  × b[7:0]  ── product[0] ──┐
-                   ├── a[15:8] × b[15:8] ── product[1] ──┤
-                   ├── a[23:16]× b[23:16]── product[2] ──┼──► partial_sum ──► accum_q (33-bit)
-                   └── a[31:24]× b[31:24]── product[3] ──┘          │             │
-b_data_i[31:0]  ──┘                                                 └── saturate ─┘
+```mermaid
+flowchart LR
+    a["a_data_i [31:0]"] --> l0["a[7:0] × b[7:0]<br>product[0]"]
+    a --> l1["a[15:8] × b[15:8]<br>product[1]"]
+    a --> l2["a[23:16] × b[23:16]<br>product[2]"]
+    a --> l3["a[31:24] × b[31:24]<br>product[3]"]
+    b["b_data_i [31:0]"] --> l0 & l1 & l2 & l3
+    l0 & l1 & l2 & l3 --> psum["partial_sum"]
+    psum --> sat["saturate"] --> acc["accum_q (33-bit)"]
+    acc --> sat
 ```
 
 - **4 parallel lanes**: each unpacks one signed INT8 byte from A and B, multiplies to produce a signed 16-bit product
@@ -55,18 +59,18 @@ Elements are packed little-endian: lane 0 reads `word[7:0]`, lane 1 reads `word[
 
 ## FSM
 
-```
-         GO (LEN>0)
-IDLE ──────── RD_A_REQ ──► RD_A_WAIT ──► RD_B_REQ ──► RD_B_WAIT
-                                                           │
-                                                           ▼
-                                                       COMPUTE
-                                                           │
-                                          remaining > 0? ──yes──► RD_A_REQ (loop)
-                                                           │
-                                                           no
-                                                           ▼
-                                                       WR_REQ ──► WR_WAIT ──► IDLE
+```mermaid
+stateDiagram-v2
+    [*] --> IDLE
+    IDLE --> RD_A_REQ : GO (LEN > 0)
+    RD_A_REQ --> RD_A_WAIT
+    RD_A_WAIT --> RD_B_REQ
+    RD_B_REQ --> RD_B_WAIT
+    RD_B_WAIT --> COMPUTE
+    COMPUTE --> RD_A_REQ : remaining > 0
+    COMPUTE --> WR_REQ : remaining == 0
+    WR_REQ --> WR_WAIT
+    WR_WAIT --> IDLE
 ```
 
 8 states. The DMA port is time-multiplexed: each iteration reads one word from A, then one word from B, then computes. After all words are processed, the result is written to the destination address.


### PR DESCRIPTION
## Summary

- Converts the sixteen ASCII-art diagrams across the seven accelerator docs (`gemm`, `softmax`, `conv2d`, `conv1d`, `vec_mac`, `sg_dma`, `pio`) to inline Mermaid code blocks, rendered natively by GitHub: FSMs become state diagrams, block/dataflow art becomes flowcharts. All sixteen blocks are parser-validated.
- Content that is data rather than a diagram is now markdown tables instead: the nine PIO instruction bit-field encodings, the gemm data-skew schedule, and the conv2d kernel weight layout.
- **CLAUDE.md**: adds Subagent Models and Development Loop process sections (spec review against the architecture docs, subagent-driven execution with independent per-task review, ledger discipline, synthesis gates, same-scale simulation twin before any KV260 run, documentation updates as a closing step), plus a Diagrams convention section (Mermaid for diagrams, tables for bit-field layouts, no ASCII art).

## Test plan

- All 16 Mermaid blocks validated with the mermaid v11 parser (16/16 OK).
- No box-drawing/ASCII diagram characters remain in `docs/` module docs or `README.md` (the private `docs/superpowers/` specs are intentionally untouched).
- Docs-only change; no RTL or build files touched.